### PR TITLE
feat: move to new endpoints for klassementen

### DIFF
--- a/src/functions/api/klassementen.ts
+++ b/src/functions/api/klassementen.ts
@@ -23,7 +23,7 @@ export const klassement_request = async (auth: AuthUse, is_admin: boolean, rank_
         role = "members"
     }
 
-    let response = await back_request(`${role}/classification/${rank_type}/`, auth, options)
+    let response = await back_request(`${role}/class/get/${rank_type}/`, auth, options)
     const punt_klas: KlassementList = KlassementList.parse(response)
     punt_klas.sort((a, b) => {
         return b.points - a.points

--- a/src/pages/Admin/components/NewEvent.tsx
+++ b/src/pages/Admin/components/NewEvent.tsx
@@ -139,7 +139,7 @@ const NewEvent = ({namesData, typeName, addText, clearEvent}: NewEventProps) => 
             'description': formState.eventDesc
         }
         try {
-            await back_post_auth("admin/ranking/update/", req, {authState, setAuthState})
+            await back_post_auth("admin/class/update/", req, {authState, setAuthState})
             await clearUpload()
         } catch (e) {
             const err = await catch_api(e)


### PR DESCRIPTION
De backend heeft nieuwe namen voor de endpoints, nu die versie een tijdje live is kunnen we overstappen. 