### PR TITLE
Add reactietest (reaction timer) game to ledenpagina

### DIFF
--- a/src/pages/leden/leden/leden.tsx
+++ b/src/pages/leden/leden/leden.tsx
@@ -9,6 +9,7 @@ const memberPages = [
   { title: "Komkommertimer", emoji: "🥒", path: "/komkommer" },
   { title: "Huisstijl", emoji: "🎨", path: "/huisstijl" },
   { title: "Website Updates", emoji: "📰", path: "/update" },
+  { title: "Reactietest", emoji: "⚡", path: "/reactietest" },
 ];
 
 export default function Leden() {

--- a/src/pages/reactietest/reactietest.scss
+++ b/src/pages/reactietest/reactietest.scss
@@ -1,0 +1,52 @@
+@use "../../variables" as v;
+
+.reactietest-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: v.$margin_y;
+  padding: v.$margin_y v.$margin_x;
+
+  @include v.respond(mobile) {
+    padding: v.$margin_mobile;
+  }
+}
+
+.reactietest-highscore {
+  font-weight: v.$bold;
+  font-size: v.$font_medium;
+  color: v.$dodeka_blauw;
+}
+
+.reactietest-tile {
+  width: 100%;
+  max-width: 32rem;
+  height: 16rem;
+  border: none;
+  border-radius: 1rem;
+  cursor: pointer;
+  color: white;
+  font-weight: v.$bold;
+  font-size: v.$font_ml;
+  text-align: center;
+  padding: v.$margin_mobile;
+  transition: background-color 0.1s ease;
+
+  &--idle,
+  &--places,
+  &--waiting {
+    background-color: v.$baan_rood;
+  }
+
+  &--go {
+    background-color: v.$dodeka_blauw;
+  }
+
+  &--early {
+    background-color: v.$dodeka_grijs;
+  }
+
+  &--result {
+    background-color: v.$dodeka_blauw90p;
+  }
+}

--- a/src/pages/reactietest/reactietest.tsx
+++ b/src/pages/reactietest/reactietest.tsx
@@ -1,0 +1,95 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import PageTitle from "$components/PageTitle.tsx";
+import "./reactietest.scss";
+
+type Phase = "idle" | "places" | "waiting" | "go" | "early" | "result";
+
+const HIGHSCORE_KEY = "reactietest-highscore";
+
+function getStoredHighscore(): number | null {
+  const raw = localStorage.getItem(HIGHSCORE_KEY);
+  if (!raw) return null;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export default function Reactietest() {
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [reactionTime, setReactionTime] = useState<number | null>(null);
+  const [highscore, setHighscore] = useState<number | null>(() =>
+    getStoredHighscore(),
+  );
+
+  const goAtRef = useRef<number | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const startRound = useCallback(() => {
+    setReactionTime(null);
+    setPhase("places");
+
+    timeoutRef.current = setTimeout(() => {
+      setPhase("waiting");
+
+      const delay = 1500 + Math.random() * 2500;
+      timeoutRef.current = setTimeout(() => {
+        goAtRef.current = performance.now();
+        setPhase("go");
+      }, delay);
+    }, 800);
+  }, []);
+
+  const handleClick = useCallback(() => {
+    if (phase === "idle" || phase === "result" || phase === "early") {
+      startRound();
+      return;
+    }
+
+    if (phase === "places" || phase === "waiting") {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      setPhase("early");
+      return;
+    }
+
+    if (phase === "go" && goAtRef.current !== null) {
+      const time = Math.round(performance.now() - goAtRef.current);
+      setReactionTime(time);
+      setPhase("result");
+
+      if (highscore === null || time < highscore) {
+        setHighscore(time);
+        localStorage.setItem(HIGHSCORE_KEY, String(time));
+      }
+    }
+  }, [phase, highscore, startRound]);
+
+  const label = {
+    idle: "Klik om te starten",
+    places: "Op uw plaatsen...",
+    waiting: "Klaar...",
+    go: "KLIK!",
+    early: "Te vroeg! Klik om het opnieuw te proberen",
+    result: `${reactionTime} ms — klik om opnieuw te proberen`,
+  }[phase];
+
+  return (
+    <div className="reactietest-page">
+      <PageTitle title="Reactietest" />
+      {highscore !== null && (
+        <p className="reactietest-highscore">Beste tijd: {highscore} ms</p>
+      )}
+      <button
+        type="button"
+        className={`reactietest-tile reactietest-tile--${phase}`}
+        onClick={handleClick}
+      >
+        {label}
+      </button>
+    </div>
+  );
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -41,6 +41,7 @@ export default [
     route("huisstijl", "./pages/Branding/Branding.tsx"),
     route("komkommer", "./pages/komkommer/komkommer.tsx"),
     route("turfjes", "./pages/turfjes/turfjes.tsx"),
+    route("reactietest", "./pages/reactietest/reactietest.tsx"),
     route("sprint", "./pages/sprint-tijden/sprint-alias.tsx"),
     route("sprint_tijden", "./pages/sprint-tijden/sprint-tijden-alias.tsx"),
     route("trainings_schema", "./pages/sprint-tijden/trainings-schema-alias.tsx"),


### PR DESCRIPTION
## Summary
- New "Reactietest" reaction-timer game tile on the leden page
- Tile shows baanrood while waiting, displays "Op uw plaatsen..." then "Klaar...", then turns dodekablauw after a random 1.5-4s delay for the user to click
- Clicking too early shows an "early" state; clicking on time records the reaction time in ms
- Personal best reaction time is saved to `localStorage` and shown above the tile

## Test plan
- [x] `npm run check` passes with no new type errors (pre-existing legacy errors unrelated to this change)
- [ ] Manually click through the tile on `/leden`: verify color/text transitions, early-click handling, and that the best time persists across reloads