### PR TITLE
Add training sign-up page for leden with trainer-managed schedules

### DIFF
--- a/docs/training-backend-spec.md
+++ b/docs/training-backend-spec.md
@@ -1,0 +1,366 @@
+# Backend Specification: Training Sign-up ("Inschrijven trainingen")
+
+This document specifies the backend for the training sign-up feature of the
+D.S.A.V. Dodeka website. It is written so an implementer (human or AI) can
+build it without access to the frontend conversation. The frontend already
+exists at `src/pages/leden/inschrijven-training/` in the `dodekafrontend`
+repository and currently runs on mock data; its TypeScript types in
+`src/pages/leden/inschrijven-training/types.ts` mirror the response shapes
+below and must stay in sync.
+
+## 1. Context and architecture
+
+The Dodeka stack consists of:
+
+- **tiauth-faroe** (port 12770) — Go auth server handling signup/signin.
+- **dodeka/backend** (port 12780) — Python API server (hfree). This is where
+  the endpoints below are implemented.
+- **dodekafrontend** — React (React Router 7) SPA, talks to the backend with
+  `credentials: include` cookie sessions.
+
+Authentication/identity is already in place: `GET /auth/session_info/`
+returns the session, including
+`user: { user_id, email, firstname, lastname, permissions: string[] }`.
+
+**Authorization model:** flat permission strings on the user, no hierarchy.
+Relevant permissions (all already exist in the admin panel):
+
+| Permission | Meaning for this feature |
+|---|---|
+| `member` | May view trainings, see schedules and trainer assignments, sign up/out. |
+| `trainers` | Everything a member may, plus: create/edit/delete/cancel trainings, edit groups (schedule, comment, trainer, T1/T2 event), remove attendees, import schedules. |
+| `bestuur` | Same rights as `trainers`, plus: view the trainingscompetitie standings. |
+| `admin` | Superset of everything above. |
+
+**Every endpoint must enforce its permission server-side** (the frontend
+check is cosmetic). A user with `trainers` OR `bestuur` OR `admin` is a
+"manager" below. Requests without a valid session get `401`; with a session
+but missing permission get `403`.
+
+## 2. Domain model
+
+A **training day** always has the same five groups ("slots"):
+
+| slot | name | schedule? | notes |
+|---|---|---|---|
+| `sprint` | fixed: "Sprint" | yes | trainers work from a prepared schedule |
+| `mila` | fixed: "MiLa" | yes | idem |
+| `loopgroep` | fixed: "Loopgroep" | yes | idem |
+| `t1` | variable, e.g. "Kogel" | **never** | technical slot 1; may be unused (name null) |
+| `t2` | variable, e.g. "Discus" | **never** | technical slot 2; may be unused (name null) |
+
+Members sign up for exactly one slot per day. There is no location field
+anywhere — trainings are always at the club's track.
+
+**Every training is staffed by five trainers.** Trainers are stored at the
+day level (never per slot): `trainers` is a comma-separated list of the
+five names, where **the first name is the contact point** of the day.
+`warmup_trainers` holds who leads the joint warming-up. All trainer names
+are visible to all members.
+
+### Suggested tables
+
+**training_days**
+| column | type | notes |
+|---|---|---|
+| training_id | text, PK | e.g. `training_2026-07-06` or uuid |
+| date | date, unique | one training day per calendar date |
+| start_time | text "HH:MM" | default by weekday: Sat "10:15", else "18:15" |
+| end_time | text "HH:MM", nullable | default: Sat "11:45", else "19:45" |
+| cancelled_reason | text, nullable | non-null ⇒ the day is cancelled |
+| cancelled_by | text (user_id), nullable | audit |
+| trainers | text, nullable | comma-separated five names; first = contact point |
+| warmup_trainers | text, nullable | who leads the joint warming-up |
+| created_at / updated_at | timestamps | |
+
+**training_events** (one row per slot, five per day)
+| column | type | notes |
+|---|---|---|
+| event_id | text, PK | |
+| training_id | FK → training_days, cascade delete | |
+| slot | enum: sprint/mila/loopgroep/t1/t2 | unique per (training_id, slot) |
+| name | text, nullable | fixed for the three groups; event name for t1/t2, null = slot unused |
+| schedule | text, nullable | multiline; must be null for t1/t2 |
+| comment | text, nullable | short trainer note, e.g. "Neem spikes mee" |
+
+**training_signups**
+| column | type | notes |
+|---|---|---|
+| event_id | FK → training_events, cascade delete | |
+| user_id | text | |
+| created_at | timestamp | |
+| removed_by | text (user_id), nullable | set when a manager removes a no-show (audit) |
+
+Constraint: **a user may have at most one active signup per training day.**
+Enforce in the signup endpoint (move semantics, §5.1), not just the UI.
+
+### Competition
+
+Points are **derived**, not stored per mutation: a user's score = number of
+distinct non-cancelled training days (in the current season) where they have
+an active signup. Compute with a query; do not maintain a counter that can
+drift. A season is a date range (configurable; default: the academic year,
+1 Sep – 31 Aug).
+
+## 3. Common conventions
+
+- All endpoints under a `/trainings/` prefix.
+- JSON in/out; snake_case keys.
+- Dates as `"YYYY-MM-DD"`, times as `"HH:MM"` (24h).
+- Attendee objects are `{ "user_id": "...", "name": "Firstname Lastname" }` —
+  the backend resolves names so the frontend never needs a separate lookup.
+- Errors: `{ "error": "machine_code", "message": "human readable" }` with an
+  appropriate 4xx status.
+
+## 4. Endpoints — read
+
+### 4.1 GET /trainings/
+Permission: `member`.
+Query params: `from` (date, default today), `to` (date, default today + 21
+days).
+Returns the training days in range, ascending by date:
+
+```json
+{
+  "trainings": [
+    {
+      "training_id": "training_2026-07-06",
+      "date": "2026-07-06",
+      "start_time": "18:15",
+      "end_time": "19:45",
+      "cancelled": null,
+      "trainers": "Jasmijn, Karel, Roos, Sven, Nina",
+      "warmup_trainers": "Jasmijn",
+      "events": [
+        {
+          "event_id": "ev_123",
+          "slot": "sprint",
+          "name": "Sprint",
+          "schedule": "Warming-up: 2 rondjes...\nKern: 3× 3×60m vliegend",
+          "comment": "Neem je spikes mee!",
+          "attendees": [
+            { "user_id": "abc", "name": "Koers Klaproos" }
+          ]
+        },
+        {
+          "event_id": "ev_124",
+          "slot": "t1",
+          "name": "Kogel",
+          "schedule": null,
+          "comment": null,
+          "attendees": []
+        }
+      ]
+    }
+  ]
+}
+```
+
+- Always all five slot objects per day, in order sprint, mila, loopgroep,
+  t1, t2. An unused technical slot has `"name": null`.
+- `trainers` (comma-separated, first name = contact point) and
+  `warmup_trainers` are day-level and visible to all members.
+- A cancelled day has `"cancelled": { "reason": "NSK Teams" }` and keeps its
+  events (signups on it don't count for the competition).
+
+### 4.2 GET /trainings/competition/
+Permission: `bestuur` or `admin` only. Regular members and trainers must get
+`403` — the standings are not public.
+Query params: `season` (optional, e.g. `2025-2026`; default current).
+
+```json
+{
+  "season": "2025-2026",
+  "standings": [
+    { "user_id": "abc", "name": "Koers Klaproos", "points": 24 }
+  ]
+}
+```
+Sorted by points descending.
+
+## 5. Endpoints — member actions
+
+### 5.1 POST /trainings/{training_id}/signup/
+Permission: `member`. Body: `{ "event_id": "ev_123" }`.
+
+Rules:
+- `404` if training or event doesn't exist; `409` (`training_cancelled`) if
+  the day is cancelled; `409` (`slot_unused`) if the slot's name is null.
+- If the user already has a signup on **another slot of the same day**, the
+  signup **moves** (delete old, create new) — one slot per day.
+- If the user is already signed up for this exact slot, respond `200`
+  idempotently.
+- Optional (recommended): reject signups for dates in the past
+  (`409 signup_closed`).
+
+Returns the updated training day (same shape as in §4.1).
+
+Competition effect: automatic — the derived score now counts this day.
+
+### 5.2 DELETE /trainings/{training_id}/signup/
+Permission: `member`. Removes the caller's signup on that day (whichever
+slot). `200` even if there was none. Returns the updated training day.
+
+## 6. Endpoints — manager actions
+
+All require `trainers`, `bestuur` or `admin`.
+
+### 6.1 POST /trainings/
+Create a training day. All five slot rows are created automatically. Body
+(everything except `date` optional):
+
+```json
+{
+  "date": "2026-07-27",
+  "start_time": "18:15",
+  "end_time": "19:45",
+  "sprint_schedule": null,
+  "mila_schedule": null,
+  "loopgroep_schedule": null,
+  "t1_event": "Kogel",
+  "t2_event": null,
+  "available_trainers": "Jasmijn, Karel, Roos, Sven, Nina",
+  "warmup_trainers": null
+}
+```
+Times default by weekday (§2). `available_trainers` maps to the day's
+`trainers` column (first name = contact point). `409` (`date_taken`) if a
+training already exists on that date.
+
+### 6.2 PATCH /trainings/{training_id}/
+Partial update of `start_time`, `end_time`, `trainers`, `warmup_trainers`.
+
+### 6.3 DELETE /trainings/{training_id}/
+Deletes the day and its events/signups.
+
+### 6.4 POST /trainings/{training_id}/cancel/
+Body: `{ "reason": "Baan onbespeelbaar" }` — reason is required, non-empty.
+Sets `cancelled_reason` + `cancelled_by`. Signups are kept but stop counting
+for the competition.
+
+### 6.5 POST /trainings/{training_id}/restore/
+Clears the cancellation.
+
+### 6.6 PATCH /trainings/{training_id}/events/{event_id}/
+Partial update of a slot:
+- `comment` — any slot.
+- `schedule` — only sprint/mila/loopgroep; `422` (`no_schedule_slot`) for
+  t1/t2.
+- `name` — only t1/t2 (`422` `fixed_name_slot` for the three groups).
+  Setting `name` to null/empty marks the slot unused and **deletes its
+  signups**.
+
+### 6.7 DELETE /trainings/{training_id}/events/{event_id}/attendees/{user_id}/
+Remove a no-show. Record `removed_by` for audit. The user's competition
+score drops accordingly (derived). Consider notifying the user (out of
+scope for v1).
+
+## 7. Schedule import
+
+Trainers prepare the whole period's schedule outside the website (typically
+a spreadsheet) and upload it in one go.
+
+### 7.1 File format
+
+One row per training day, eight columns:
+
+| column | maps to |
+|---|---|
+| `date` | training_days.date (YYYY-MM-DD) |
+| `sprint schedule` | sprint slot schedule (may be multiline) |
+| `mila schedule` | mila slot schedule |
+| `loopgroep schedule` | loopgroep slot schedule |
+| `t1 event` | t1 slot name (empty = unused) |
+| `t2 event` | t2 slot name (empty = unused) |
+| `available trainers` | the five trainers of the day, comma-separated → training_days.trainers; **the first name is the contact point** |
+| `warmup trainers` | training_days.warmup_trainers |
+
+CSV example (cells may be quoted and contain commas/newlines, standard
+Excel/Sheets export):
+
+```csv
+date,sprint schedule,mila schedule,loopgroep schedule,t1 event,t2 event,available trainers,warm-up trainers
+2026-07-06,"Kern: 3× 3×60m vliegend","6× 800m, rust 90""","40' duurloop D1/D2",Kogel,Discus,"Jasmijn, Karel, Roos, Sven, Nina",Jasmijn
+2026-07-08,"4× starts uit blokken","8× 400m","35' duurloop",Ver,,"Karel, Roos, Jasmijn, Nina, Sven",Roos
+```
+
+JSON equivalent: an array of objects with keys `date`, `sprint_schedule`,
+`mila_schedule`, `loopgroep_schedule`, `t1_event`, `t2_event`,
+`available_trainers`, `warmup_trainers` (missing/empty ⇒ null).
+
+Start/end times are not in the file; they default by weekday (§2).
+
+### 7.2 POST /trainings/import/
+Permission: manager. The frontend parses the file client-side and submits
+the parsed JSON (canonical); accepting raw CSV `multipart/form-data` is
+optional.
+
+Body:
+
+```json
+{
+  "mode": "per_item",
+  "trainings": [
+    {
+      "date": "2026-07-06",
+      "sprint_schedule": "Kern: 3× 3×60m vliegend",
+      "mila_schedule": "6× 800m, rust 90\"",
+      "loopgroep_schedule": "40' duurloop D1/D2",
+      "t1_event": "Kogel",
+      "t2_event": "Discus",
+      "available_trainers": "Jasmijn, Karel, Roos, Sven, Nina",
+      "warmup_trainers": "Jasmijn"
+    }
+  ],
+  "replace_dates": ["2026-07-06"]
+}
+```
+
+Conflict semantics (a conflict = an imported `date` that already has a
+training day):
+
+| `mode` | behaviour |
+|---|---|
+| `overwrite_all` | every conflicting existing day is deleted and replaced |
+| `skip_existing` | conflicting imported items are ignored, existing days stay |
+| `per_item` | only dates listed in `replace_dates` are replaced; other conflicting imports are skipped |
+
+The two-step UX the frontend implements: it first detects conflicts from the
+already-loaded `GET /trainings/` data, asks the trainer to choose per date
+(or "replace all" / "keep all"), then submits with `mode: "per_item"` and the
+chosen `replace_dates`. A dry-run endpoint is therefore not required for v1,
+but the import must be **transactional**: all or nothing.
+
+Replacing a day deletes its signups (users signed up for a replaced future
+training should ideally be notified — out of scope for v1, note it in the
+response as `"replaced_with_signups": [dates]`).
+
+Response: `{ "created": 12, "replaced": 2, "skipped": 1 }`.
+
+## 8. Business rules summary
+
+1. One training day per date; five fixed slots per day; one active signup
+   per user per day.
+2. Every training is staffed by five trainers, stored at the day level
+   (never per slot). The first name in the list is the contact point; the
+   warming-up lead is stored separately. All trainer names are visible to
+   members.
+3. Signing up for another slot on the same day moves the signup.
+4. Sprint/MiLa/Loopgroep have schedules; T1/T2 never do. T1/T2 names are
+   editable, group names are not.
+5. Cancelling requires a reason and is reversible; cancelled days count for
+   nobody in the competition.
+6. Competition points = count of distinct non-cancelled days with an active
+   signup within the season. Removing a no-show retracts that day's point.
+7. Standings are visible to `bestuur`/`admin` only.
+8. All writes require manager permissions except signup/sign-out.
+9. Import is transactional and follows the conflict mode of §7.2.
+
+## 9. Out of scope for v1 (planned, don't block on these)
+
+- Email/push notifications on cancellation or removal.
+- Max capacity + waitlists per slot.
+- Signup deadlines (e.g. closes 2h before start).
+- Attendance check-in by trainers on the day itself (would make the
+  competition reflect *attendance* instead of *signup*).
+- iCal feed of the training calendar.

--- a/docs/training-backend-spec.md
+++ b/docs/training-backend-spec.md
@@ -257,12 +257,21 @@ scope for v1).
 
 ## 7. Schedule import
 
-Trainers prepare the whole period's schedule outside the website (typically
-a spreadsheet) and upload it in one go.
+Trainers prepare schedules outside the website (typically a spreadsheet).
+There are two import flows:
 
-### 7.1 File format
+1. **Full import** — one file with everything for the period (days, T1/T2
+   events, trainers, optionally schedules).
+2. **Per-group import** — schedules are made per group: the Sprint trainer
+   delivers all Sprint schedules, not the MiLa ones. Each of the three
+   schedule groups can therefore be uploaded separately (§7.3).
 
-One row per training day, eight columns:
+### 7.1 Full-import file format
+
+One row per training day. **Only the `date` column is required** — the file
+may contain any subset of the remaining columns (dynamic width); missing or
+empty cells mean "not set". Columns beyond the eight below are ignored.
+T1/T2 never carry a schedule — the file only has a name column for them:
 
 | column | maps to |
 |---|---|
@@ -337,6 +346,39 @@ response as `"replaced_with_signups": [dates]`).
 
 Response: `{ "created": 12, "replaced": 2, "skipped": 1 }`.
 
+### 7.3 POST /trainings/import/schedules/
+Permission: manager. Per-group schedule import: one trainer uploads all
+schedules for their own group in one go. File format: two columns,
+`date, schedule` (CSV, quoted multiline cells allowed) or JSON
+`[{ "date": "...", "schedule": "..." }]`.
+
+Body:
+
+```json
+{
+  "slot": "sprint",
+  "mode": "per_item",
+  "schedules": [
+    { "date": "2026-07-06", "schedule": "Kern: 3× 3×60m vliegend" },
+    { "date": "2026-07-08", "schedule": "4× starts uit blokken" }
+  ],
+  "replace_dates": ["2026-07-06"]
+}
+```
+
+- `slot` must be `sprint`, `mila` or `loopgroep` — `422`
+  (`no_schedule_slot`) for t1/t2.
+- If the training day does not exist yet, it is **created** with default
+  times (§2) and only this group's schedule set. Signups and other groups
+  are never touched by this endpoint.
+- If the day exists and the group's schedule is empty, it is filled in.
+- If the day exists and the group already has a schedule, the conflict mode
+  applies (same `overwrite_all` / `skip_existing` / `per_item` semantics as
+  §7.2, where a conflict = date whose group schedule is already set).
+- Transactional: all or nothing.
+
+Response: `{ "days_created": 3, "schedules_set": 9, "skipped": 1 }`.
+
 ## 8. Business rules summary
 
 1. One training day per date; five fixed slots per day; one active signup
@@ -354,7 +396,9 @@ Response: `{ "created": 12, "replaced": 2, "skipped": 1 }`.
    signup within the season. Removing a no-show retracts that day's point.
 7. Standings are visible to `bestuur`/`admin` only.
 8. All writes require manager permissions except signup/sign-out.
-9. Import is transactional and follows the conflict mode of §7.2.
+9. Imports are transactional and follow the conflict modes of §7.2/§7.3.
+   Schedules are delivered per group (§7.3); the full import (§7.2) needs
+   only a date column, all other columns are optional.
 
 ## 9. Out of scope for v1 (planned, don't block on these)
 

--- a/src/pages/layout.css
+++ b/src/pages/layout.css
@@ -47,7 +47,9 @@
 }
 
 #app_flex {
-  overflow: hidden;
+  /* clip instead of hidden: same clipping, but doesn't create a scroll
+     container, so position: sticky keeps working for descendants */
+  overflow: clip;
   display: flex;
   flex-direction: column;
   min-height: calc(100vh - 4rem);

--- a/src/pages/leden/inschrijven-training/components/CompetitionPanel.scss
+++ b/src/pages/leden/inschrijven-training/components/CompetitionPanel.scss
@@ -1,0 +1,86 @@
+@import "../../../../variables";
+
+.competition-panel {
+  background: white;
+  border: 1px solid #e3c56e;
+  background: linear-gradient(180deg, #fffaf0, #fff);
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.competition-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0.8rem 1.1rem;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font: inherit;
+}
+
+.competition-title {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  color: $dodeka_blauw;
+  font-weight: $bold;
+  font-size: 1.05rem;
+}
+
+.competition-boardonly {
+  font-size: 0.75rem;
+  font-weight: $normal;
+  color: #8a5a19;
+  background: #fdf3e4;
+  border-radius: 999px;
+  padding: 0.15rem 0.6rem;
+}
+
+.competition-chevron {
+  color: #93a3b1;
+  transition: transform 0.15s ease;
+
+  &.is-open {
+    transform: rotate(180deg);
+  }
+}
+
+.competition-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+
+  th,
+  td {
+    text-align: left;
+    padding: 0.45rem 1.1rem;
+  }
+
+  th {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: #5d6f80;
+    border-bottom: 1px solid #eee3c8;
+  }
+
+  td {
+    color: $dodeka_blauw;
+    border-bottom: 1px solid #f6efdd;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+
+  td:first-child {
+    width: 2.5rem;
+    color: #93a3b1;
+  }
+
+  td:last-child {
+    font-weight: $bold;
+  }
+}

--- a/src/pages/leden/inschrijven-training/components/CompetitionPanel.tsx
+++ b/src/pages/leden/inschrijven-training/components/CompetitionPanel.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import type { CompetitionStanding } from "../types";
+import "./CompetitionPanel.scss";
+
+// Standings of the trainingscompetitie. Only rendered for board members
+// (bestuur/admin) — regular members and trainers never see the points.
+export default function CompetitionPanel(props: {
+  standings: CompetitionStanding[];
+}) {
+  const [open, setOpen] = useState(false);
+  const sorted = [...props.standings].sort((a, b) => b.points - a.points);
+
+  return (
+    <section className="competition-panel">
+      <button className="competition-header" onClick={() => setOpen(!open)}>
+        <span className="competition-title">
+          🏆 Trainingscompetitie
+          <span className="competition-boardonly">alleen zichtbaar voor bestuur</span>
+        </span>
+        <span className={`competition-chevron ${open ? "is-open" : ""}`} aria-hidden>
+          ▾
+        </span>
+      </button>
+      {open && (
+        <table className="competition-table">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Naam</th>
+              <th>Punten</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((standing, i) => (
+              <tr key={standing.user_id}>
+                <td>{i + 1}</td>
+                <td>{standing.name}</td>
+                <td>{standing.points}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+}

--- a/src/pages/leden/inschrijven-training/components/ImportModal.scss
+++ b/src/pages/leden/inschrijven-training/components/ImportModal.scss
@@ -51,6 +51,32 @@
   }
 }
 
+// What to import: full schema or one group's schedules.
+.import-mode-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0.6rem 0 0.2rem;
+
+  button {
+    font: inherit;
+    font-size: 0.9rem;
+    font-weight: $bold;
+    padding: 0.35rem 1rem;
+    border-radius: 8px;
+    border: 1px solid #b7c3cf;
+    background: white;
+    color: #5d6f80;
+    cursor: pointer;
+
+    &.is-active {
+      background: $dodeka_rood;
+      border-color: $dodeka_rood;
+      color: white;
+    }
+  }
+}
+
 .import-format-tabs {
   display: flex;
   gap: 0.4rem;

--- a/src/pages/leden/inschrijven-training/components/ImportModal.scss
+++ b/src/pages/leden/inschrijven-training/components/ImportModal.scss
@@ -1,0 +1,140 @@
+@import "../../../../variables";
+
+.import-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 31, 72, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 1rem;
+}
+
+.import-modal {
+  background: white;
+  border-radius: 14px;
+  padding: 1.2rem 1.4rem;
+  width: 34rem;
+  max-width: 100%;
+  max-height: 85vh;
+  overflow-y: auto;
+  box-shadow: 0 10px 40px rgba(0, 31, 72, 0.3);
+
+  p {
+    color: $dodeka_blauw;
+    font-size: 0.95rem;
+  }
+}
+
+.import-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  h3 {
+    margin: 0;
+    color: $dodeka_blauw;
+  }
+}
+
+.import-close {
+  border: none;
+  background: none;
+  font-size: 1.6rem;
+  line-height: 1;
+  color: #93a3b1;
+  cursor: pointer;
+
+  &:hover {
+    color: $dodeka_rood;
+  }
+}
+
+.import-format-tabs {
+  display: flex;
+  gap: 0.4rem;
+  margin-bottom: 0.5rem;
+
+  button {
+    font: inherit;
+    font-size: 0.85rem;
+    font-weight: $bold;
+    padding: 0.25rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid #b7c3cf;
+    background: white;
+    color: #5d6f80;
+    cursor: pointer;
+
+    &.is-active {
+      background: $dodeka_blauw;
+      border-color: $dodeka_blauw;
+      color: white;
+    }
+  }
+}
+
+.import-example {
+  background: #f6f8fa;
+  border: 1px solid #e3e8ee;
+  border-radius: 8px;
+  padding: 0.7rem 0.9rem;
+  font-size: 0.8rem;
+  overflow-x: auto;
+  color: $dodeka_blauw;
+}
+
+.import-error {
+  color: $dodeka_rood;
+  font-weight: $bold;
+}
+
+.import-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+  margin-top: 1rem;
+}
+
+.import-conflicts {
+  border: 1px solid #f0d9d5;
+  background: #fdf7f6;
+  border-radius: 10px;
+  padding: 0.8rem 1rem;
+
+  ul {
+    list-style: none;
+    margin: 0.6rem 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+}
+
+.import-conflict-bulk {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.import-conflict-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+  font-size: 0.9rem;
+  color: $dodeka_blauw;
+
+  .import-conflict-date {
+    font-weight: $bold;
+    min-width: 9rem;
+  }
+
+  label {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    cursor: pointer;
+  }
+}

--- a/src/pages/leden/inschrijven-training/components/ImportModal.tsx
+++ b/src/pages/leden/inschrijven-training/components/ImportModal.tsx
@@ -1,15 +1,35 @@
 import { useRef, useState } from "react";
-import type { ImportedTraining } from "../types";
-import { formatDayMonth, formatWeekday, parseImportFile } from "../utils";
+import type {
+  ImportedGroupSchedule,
+  ImportedTraining,
+  ScheduleSlot,
+  TrainingDay,
+} from "../types";
+import {
+  FIXED_SLOT_NAMES,
+  formatDayMonth,
+  formatWeekday,
+  parseGroupScheduleFile,
+  parseImportFile,
+} from "../utils";
 import "./ImportModal.scss";
 
-// "available trainers": the five trainers of the day, first name is the
-// contact point.
-const CSV_EXAMPLE = `date,sprint schedule,mila schedule,loopgroep schedule,t1 event,t2 event,available trainers,warm-up trainers
+// What is being imported: the full week schedule, or one group's schedules
+// (a sprint trainer delivers all Sprint trainings, not the MiLa ones).
+type ImportMode = "full" | ScheduleSlot;
+
+const MODE_LABELS: { mode: ImportMode; label: string }[] = [
+  { mode: "full", label: "Volledig schema" },
+  { mode: "sprint", label: "Sprint" },
+  { mode: "mila", label: "MiLa" },
+  { mode: "loopgroep", label: "Loopgroep" },
+];
+
+const FULL_CSV_EXAMPLE = `date,sprint schedule,mila schedule,loopgroep schedule,t1 event,t2 event,available trainers,warm-up trainers
 2026-07-06,"Kern: 3× 3×60m vliegend","6× 800m, rust 90\\"","40' duurloop D1/D2",Kogel,Discus,"Jasmijn, Karel, Roos, Sven, Nina",Jasmijn
 2026-07-08,"4× starts uit blokken","8× 400m","35' duurloop",Ver,,"Karel, Roos, Jasmijn, Nina, Sven",Roos`;
 
-const JSON_EXAMPLE = `[
+const FULL_JSON_EXAMPLE = `[
   {
     "date": "2026-07-06",
     "sprint_schedule": "Kern: 3× 3×60m vliegend",
@@ -22,65 +42,130 @@ const JSON_EXAMPLE = `[
   }
 ]`;
 
+const GROUP_CSV_EXAMPLE = `date,schedule
+2026-07-06,"Kern: 3× 3×60m vliegend, rust 3'"
+2026-07-08,"4× starts uit blokken + core"`;
+
+const GROUP_JSON_EXAMPLE = `[
+  { "date": "2026-07-06", "schedule": "Kern: 3× 3×60m vliegend" },
+  { "date": "2026-07-08", "schedule": "4× starts uit blokken" }
+]`;
+
 interface ImportModalProps {
-  // Dates that already have a training, used for conflict detection.
-  existingDates: string[];
+  trainings: TrainingDay[];
   onClose: () => void;
-  // Trainings to add + the existing dates the trainer chose to overwrite.
+  // Full import: trainings to add + existing dates to overwrite.
   onImport: (trainings: ImportedTraining[], replaceDates: string[]) => void;
+  // Per-group import: set one group's schedules; days that don't exist yet
+  // are created, existing schedules only overwritten for replaceDates.
+  onImportGroup: (
+    slot: ScheduleSlot,
+    items: ImportedGroupSchedule[],
+    replaceDates: string[],
+  ) => void;
 }
 
 export default function ImportModal(props: ImportModalProps) {
+  const [mode, setMode] = useState<ImportMode>("full");
+  const [format, setFormat] = useState<"csv" | "json">("csv");
   const [error, setError] = useState<string | null>(null);
-  const [parsed, setParsed] = useState<ImportedTraining[] | null>(null);
+  const [parsedFull, setParsedFull] = useState<ImportedTraining[] | null>(
+    null,
+  );
+  const [parsedGroup, setParsedGroup] = useState<
+    ImportedGroupSchedule[] | null
+  >(null);
   const [choices, setChoices] = useState<Record<string, "replace" | "keep">>(
     {},
   );
-  const [format, setFormat] = useState<"csv" | "json">("csv");
   const fileInput = useRef<HTMLInputElement>(null);
 
-  const conflicts = (parsed ?? []).filter((t) =>
-    props.existingDates.includes(t.date),
-  );
+  const existingDates = props.trainings.map((t) => t.date);
+  // A conflict needs a per-date decision: for the full import that's any
+  // existing day; for a group import only days where that group already has
+  // a schedule (empty schedules are filled in without asking).
+  function isConflict(date: string): boolean {
+    if (mode === "full") return existingDates.includes(date);
+    const day = props.trainings.find((t) => t.date === date);
+    if (!day) return false;
+    return day.events.some(
+      (event) => event.slot === mode && event.schedule !== null,
+    );
+  }
+
+  const parsedDates =
+    (mode === "full"
+      ? parsedFull?.map((t) => t.date)
+      : parsedGroup?.map((t) => t.date)) ?? [];
+  const conflicts = parsedDates.filter(isConflict);
+  const parsed = mode === "full" ? parsedFull : parsedGroup;
 
   async function handleFile(file: File) {
     setError(null);
     try {
       const content = await file.text();
-      const trainings = parseImportFile(file.name, content);
-      if (trainings.length === 0) {
-        setError("Geen trainingen gevonden in het bestand.");
-        return;
+      if (mode === "full") {
+        const trainings = parseImportFile(file.name, content);
+        if (trainings.length === 0) {
+          setError("Geen trainingen gevonden in het bestand.");
+          return;
+        }
+        setParsedFull(trainings);
+        setChoices(
+          Object.fromEntries(
+            trainings
+              .filter((t) => isConflict(t.date))
+              .map((t) => [t.date, "keep" as const]),
+          ),
+        );
+      } else {
+        const items = parseGroupScheduleFile(file.name, content);
+        if (items.length === 0) {
+          setError("Geen schema's gevonden in het bestand.");
+          return;
+        }
+        setParsedGroup(items);
+        setChoices(
+          Object.fromEntries(
+            items
+              .filter((t) => isConflict(t.date))
+              .map((t) => [t.date, "keep" as const]),
+          ),
+        );
       }
-      setParsed(trainings);
-      const conflicting = trainings.filter((t) =>
-        props.existingDates.includes(t.date),
-      );
-      setChoices(
-        Object.fromEntries(conflicting.map((t) => [t.date, "keep" as const])),
-      );
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Bestand kon niet worden gelezen.");
+      setError(
+        e instanceof Error ? e.message : "Bestand kon niet worden gelezen.",
+      );
     }
   }
 
   function apply() {
-    if (!parsed) return;
     const replaceDates = Object.entries(choices)
       .filter(([, choice]) => choice === "replace")
       .map(([date]) => date);
-    const toImport = parsed.filter(
-      (t) =>
-        !props.existingDates.includes(t.date) || replaceDates.includes(t.date),
-    );
-    props.onImport(toImport, replaceDates);
+    if (mode === "full" && parsedFull) {
+      const toImport = parsedFull.filter(
+        (t) => !existingDates.includes(t.date) || replaceDates.includes(t.date),
+      );
+      props.onImport(toImport, replaceDates);
+    } else if (mode !== "full" && parsedGroup) {
+      props.onImportGroup(mode, parsedGroup, replaceDates);
+    }
+  }
+
+  function reset() {
+    setParsedFull(null);
+    setParsedGroup(null);
+    setChoices({});
+    setError(null);
   }
 
   function setAll(choice: "replace" | "keep") {
-    setChoices(
-      Object.fromEntries(conflicts.map((t) => [t.date, choice])),
-    );
+    setChoices(Object.fromEntries(conflicts.map((date) => [date, choice])));
   }
+
+  const groupName = mode === "full" ? null : (FIXED_SLOT_NAMES[mode] ?? mode);
 
   return (
     <div className="import-overlay" onClick={props.onClose}>
@@ -94,14 +179,38 @@ export default function ImportModal(props: ImportModalProps) {
 
         {parsed === null ? (
           <>
-            <p>
-              Upload het schema voor de komende periode in één keer als CSV
-              (bijv. een export uit Excel of Sheets) of JSON. Per dag: de
-              schema's voor Sprint, MiLa en Loopgroep, de technische
-              onderdelen (T1/T2) en de trainersbezetting. De kolom{" "}
-              <i>available trainers</i> bevat de vijf trainers van die dag;
-              de <b>eerste naam is het aanspreekpunt</b>.
-            </p>
+            <div className="import-mode-tabs">
+              {MODE_LABELS.map(({ mode: m, label }) => (
+                <button
+                  key={m}
+                  className={mode === m ? "is-active" : ""}
+                  onClick={() => {
+                    setMode(m);
+                    reset();
+                  }}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+
+            {mode === "full" ? (
+              <p>
+                Upload het complete schema voor de komende periode. Alleen de
+                datumkolom is verplicht — lege of ontbrekende kolommen worden
+                overgeslagen. T1 en T2 hebben nooit een schema, alleen een
+                onderdeelnaam. De kolom <i>available trainers</i> bevat de
+                trainers van die dag; de <b>eerste naam is het aanspreekpunt</b>.
+              </p>
+            ) : (
+              <p>
+                Upload alle <b>{groupName}</b>-schema's voor de komende
+                periode in één keer: twee kolommen, datum en schema.
+                Trainingsdagen die nog niet bestaan worden aangemaakt; dagen
+                zonder {groupName}-schema worden aangevuld.
+              </p>
+            )}
+
             <div className="import-format-tabs">
               <button
                 className={format === "csv" ? "is-active" : ""}
@@ -117,7 +226,13 @@ export default function ImportModal(props: ImportModalProps) {
               </button>
             </div>
             <pre className="import-example">
-              {format === "csv" ? CSV_EXAMPLE : JSON_EXAMPLE}
+              {mode === "full"
+                ? format === "csv"
+                  ? FULL_CSV_EXAMPLE
+                  : FULL_JSON_EXAMPLE
+                : format === "csv"
+                  ? GROUP_CSV_EXAMPLE
+                  : GROUP_JSON_EXAMPLE}
             </pre>
             {error && <p className="import-error">{error}</p>}
             <div className="import-actions">
@@ -129,6 +244,7 @@ export default function ImportModal(props: ImportModalProps) {
                 onChange={(e) => {
                   const file = e.target.files?.[0];
                   if (file) handleFile(file);
+                  e.target.value = "";
                 }}
               />
               <button
@@ -142,11 +258,15 @@ export default function ImportModal(props: ImportModalProps) {
         ) : (
           <>
             <p>
-              <b>{parsed.length}</b> trainingen gevonden
+              <b>{parsed.length}</b>{" "}
+              {mode === "full" ? "trainingen" : `${groupName}-schema's`}{" "}
+              gevonden
               {conflicts.length > 0 && (
                 <>
-                  , waarvan <b>{conflicts.length}</b> op een datum waar al een
-                  training staat.
+                  , waarvan <b>{conflicts.length}</b>{" "}
+                  {mode === "full"
+                    ? "op een datum waar al een training staat."
+                    : `op een dag die al een ${groupName}-schema heeft.`}
                 </>
               )}
             </p>
@@ -154,26 +274,32 @@ export default function ImportModal(props: ImportModalProps) {
             {conflicts.length > 0 && (
               <div className="import-conflicts">
                 <div className="import-conflict-bulk">
-                  <button className="btn btn-small" onClick={() => setAll("replace")}>
+                  <button
+                    className="btn btn-small"
+                    onClick={() => setAll("replace")}
+                  >
                     Alles vervangen
                   </button>
-                  <button className="btn btn-small btn-ghost" onClick={() => setAll("keep")}>
+                  <button
+                    className="btn btn-small btn-ghost"
+                    onClick={() => setAll("keep")}
+                  >
                     Alles behouden
                   </button>
                 </div>
                 <ul>
-                  {conflicts.map((training) => (
-                    <li key={training.date} className="import-conflict-row">
+                  {conflicts.map((date) => (
+                    <li key={date} className="import-conflict-row">
                       <span className="import-conflict-date">
-                        {formatWeekday(training.date)} {formatDayMonth(training.date)}
+                        {formatWeekday(date)} {formatDayMonth(date)}
                       </span>
                       <label>
                         <input
                           type="radio"
-                          name={`conflict-${training.date}`}
-                          checked={choices[training.date] === "keep"}
+                          name={`conflict-${date}`}
+                          checked={choices[date] === "keep"}
                           onChange={() =>
-                            setChoices({ ...choices, [training.date]: "keep" })
+                            setChoices({ ...choices, [date]: "keep" })
                           }
                         />
                         Bestaande behouden
@@ -181,13 +307,10 @@ export default function ImportModal(props: ImportModalProps) {
                       <label>
                         <input
                           type="radio"
-                          name={`conflict-${training.date}`}
-                          checked={choices[training.date] === "replace"}
+                          name={`conflict-${date}`}
+                          checked={choices[date] === "replace"}
                           onChange={() =>
-                            setChoices({
-                              ...choices,
-                              [training.date]: "replace",
-                            })
+                            setChoices({ ...choices, [date]: "replace" })
                           }
                         />
                         Vervangen
@@ -199,7 +322,7 @@ export default function ImportModal(props: ImportModalProps) {
             )}
 
             <div className="import-actions">
-              <button className="btn btn-ghost" onClick={() => setParsed(null)}>
+              <button className="btn btn-ghost" onClick={reset}>
                 Ander bestand
               </button>
               <button className="btn btn-primary" onClick={apply}>

--- a/src/pages/leden/inschrijven-training/components/ImportModal.tsx
+++ b/src/pages/leden/inschrijven-training/components/ImportModal.tsx
@@ -1,0 +1,214 @@
+import { useRef, useState } from "react";
+import type { ImportedTraining } from "../types";
+import { formatDayMonth, formatWeekday, parseImportFile } from "../utils";
+import "./ImportModal.scss";
+
+// "available trainers": the five trainers of the day, first name is the
+// contact point.
+const CSV_EXAMPLE = `date,sprint schedule,mila schedule,loopgroep schedule,t1 event,t2 event,available trainers,warm-up trainers
+2026-07-06,"Kern: 3× 3×60m vliegend","6× 800m, rust 90\\"","40' duurloop D1/D2",Kogel,Discus,"Jasmijn, Karel, Roos, Sven, Nina",Jasmijn
+2026-07-08,"4× starts uit blokken","8× 400m","35' duurloop",Ver,,"Karel, Roos, Jasmijn, Nina, Sven",Roos`;
+
+const JSON_EXAMPLE = `[
+  {
+    "date": "2026-07-06",
+    "sprint_schedule": "Kern: 3× 3×60m vliegend",
+    "mila_schedule": "6× 800m, rust 90\\"",
+    "loopgroep_schedule": "40' duurloop D1/D2",
+    "t1_event": "Kogel",
+    "t2_event": "Discus",
+    "available_trainers": "Jasmijn, Karel, Roos, Sven, Nina",
+    "warmup_trainers": "Jasmijn"
+  }
+]`;
+
+interface ImportModalProps {
+  // Dates that already have a training, used for conflict detection.
+  existingDates: string[];
+  onClose: () => void;
+  // Trainings to add + the existing dates the trainer chose to overwrite.
+  onImport: (trainings: ImportedTraining[], replaceDates: string[]) => void;
+}
+
+export default function ImportModal(props: ImportModalProps) {
+  const [error, setError] = useState<string | null>(null);
+  const [parsed, setParsed] = useState<ImportedTraining[] | null>(null);
+  const [choices, setChoices] = useState<Record<string, "replace" | "keep">>(
+    {},
+  );
+  const [format, setFormat] = useState<"csv" | "json">("csv");
+  const fileInput = useRef<HTMLInputElement>(null);
+
+  const conflicts = (parsed ?? []).filter((t) =>
+    props.existingDates.includes(t.date),
+  );
+
+  async function handleFile(file: File) {
+    setError(null);
+    try {
+      const content = await file.text();
+      const trainings = parseImportFile(file.name, content);
+      if (trainings.length === 0) {
+        setError("Geen trainingen gevonden in het bestand.");
+        return;
+      }
+      setParsed(trainings);
+      const conflicting = trainings.filter((t) =>
+        props.existingDates.includes(t.date),
+      );
+      setChoices(
+        Object.fromEntries(conflicting.map((t) => [t.date, "keep" as const])),
+      );
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Bestand kon niet worden gelezen.");
+    }
+  }
+
+  function apply() {
+    if (!parsed) return;
+    const replaceDates = Object.entries(choices)
+      .filter(([, choice]) => choice === "replace")
+      .map(([date]) => date);
+    const toImport = parsed.filter(
+      (t) =>
+        !props.existingDates.includes(t.date) || replaceDates.includes(t.date),
+    );
+    props.onImport(toImport, replaceDates);
+  }
+
+  function setAll(choice: "replace" | "keep") {
+    setChoices(
+      Object.fromEntries(conflicts.map((t) => [t.date, choice])),
+    );
+  }
+
+  return (
+    <div className="import-overlay" onClick={props.onClose}>
+      <div className="import-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="import-modal-header">
+          <h3>Schema importeren</h3>
+          <button className="import-close" onClick={props.onClose}>
+            ×
+          </button>
+        </div>
+
+        {parsed === null ? (
+          <>
+            <p>
+              Upload het schema voor de komende periode in één keer als CSV
+              (bijv. een export uit Excel of Sheets) of JSON. Per dag: de
+              schema's voor Sprint, MiLa en Loopgroep, de technische
+              onderdelen (T1/T2) en de trainersbezetting. De kolom{" "}
+              <i>available trainers</i> bevat de vijf trainers van die dag;
+              de <b>eerste naam is het aanspreekpunt</b>.
+            </p>
+            <div className="import-format-tabs">
+              <button
+                className={format === "csv" ? "is-active" : ""}
+                onClick={() => setFormat("csv")}
+              >
+                CSV
+              </button>
+              <button
+                className={format === "json" ? "is-active" : ""}
+                onClick={() => setFormat("json")}
+              >
+                JSON
+              </button>
+            </div>
+            <pre className="import-example">
+              {format === "csv" ? CSV_EXAMPLE : JSON_EXAMPLE}
+            </pre>
+            {error && <p className="import-error">{error}</p>}
+            <div className="import-actions">
+              <input
+                ref={fileInput}
+                type="file"
+                accept=".csv,.json,text/csv,application/json"
+                hidden
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  if (file) handleFile(file);
+                }}
+              />
+              <button
+                className="btn btn-primary"
+                onClick={() => fileInput.current?.click()}
+              >
+                Kies bestand…
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <p>
+              <b>{parsed.length}</b> trainingen gevonden
+              {conflicts.length > 0 && (
+                <>
+                  , waarvan <b>{conflicts.length}</b> op een datum waar al een
+                  training staat.
+                </>
+              )}
+            </p>
+
+            {conflicts.length > 0 && (
+              <div className="import-conflicts">
+                <div className="import-conflict-bulk">
+                  <button className="btn btn-small" onClick={() => setAll("replace")}>
+                    Alles vervangen
+                  </button>
+                  <button className="btn btn-small btn-ghost" onClick={() => setAll("keep")}>
+                    Alles behouden
+                  </button>
+                </div>
+                <ul>
+                  {conflicts.map((training) => (
+                    <li key={training.date} className="import-conflict-row">
+                      <span className="import-conflict-date">
+                        {formatWeekday(training.date)} {formatDayMonth(training.date)}
+                      </span>
+                      <label>
+                        <input
+                          type="radio"
+                          name={`conflict-${training.date}`}
+                          checked={choices[training.date] === "keep"}
+                          onChange={() =>
+                            setChoices({ ...choices, [training.date]: "keep" })
+                          }
+                        />
+                        Bestaande behouden
+                      </label>
+                      <label>
+                        <input
+                          type="radio"
+                          name={`conflict-${training.date}`}
+                          checked={choices[training.date] === "replace"}
+                          onChange={() =>
+                            setChoices({
+                              ...choices,
+                              [training.date]: "replace",
+                            })
+                          }
+                        />
+                        Vervangen
+                      </label>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            <div className="import-actions">
+              <button className="btn btn-ghost" onClick={() => setParsed(null)}>
+                Ander bestand
+              </button>
+              <button className="btn btn-primary" onClick={apply}>
+                Importeren
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/leden/inschrijven-training/components/TrainingCard.scss
+++ b/src/pages/leden/inschrijven-training/components/TrainingCard.scss
@@ -584,3 +584,153 @@ $slot_t2: #a3456b;
     width: 10rem;
   }
 }
+
+// --- Design exploration (DEV switcher: Design Huidig/A/B/C) -----------------
+// Three alternative treatments of the event panels, toggled via a class on
+// .training-page. Once a direction is chosen, the winner gets folded into
+// the base styles above and this section is removed.
+
+// Variant A — "Rustig": no containers at all. Groups are separated by
+// whitespace and a thin divider; the slot color shrinks to a small dot at
+// the group name. Hierarchy comes from typography.
+.design-a {
+  .event-panel {
+    background: none;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    overflow: visible;
+    padding-bottom: 0.85rem;
+    border-bottom: 1px solid #e8edf3;
+
+    &:last-child {
+      border-bottom: none;
+      padding-bottom: 0.2rem;
+    }
+  }
+
+  .event-panel-header {
+    background: none;
+    border-bottom: none;
+    padding: 0 0 0.2rem;
+
+    .event-name::before {
+      content: "";
+      flex-shrink: 0;
+      width: 0.55rem;
+      height: 0.55rem;
+      border-radius: 50%;
+      background: var(--slot-color);
+    }
+  }
+
+  .event-panel-body {
+    padding: 0 0 0 1.05rem;
+  }
+
+  .event-schedule {
+    background: none;
+    border: none;
+    border-radius: 0;
+    padding: 0;
+  }
+
+  .event-comment {
+    background: none;
+    padding: 0;
+    color: #8a5a19;
+  }
+
+  .event-attendees {
+    background: none;
+    padding: 0;
+    margin-top: 0.2rem;
+  }
+
+  .attendee-chip {
+    background: #f1f4f7;
+    border-color: transparent;
+  }
+}
+
+// Variant B — "Vlak": one soft flat container per group with the colored
+// spine kept, but no nested boxes inside — schedule and attendees are plain
+// content within the panel.
+.design-b {
+  .event-panel {
+    background: #f6f8fa;
+    border: none;
+    border-left: 4px solid var(--slot-color);
+    box-shadow: none;
+  }
+
+  .event-panel-header {
+    background: none;
+    border-bottom: none;
+    padding-bottom: 0.05rem;
+  }
+
+  .event-schedule {
+    background: none;
+    border: none;
+    border-radius: 0;
+    padding: 0;
+  }
+
+  .event-comment {
+    background: none;
+    padding: 0;
+    color: #8a5a19;
+  }
+
+  .event-attendees {
+    background: none;
+    border-top: 1px dashed #d5dce4;
+    border-radius: 0;
+    padding: 0.5rem 0 0;
+  }
+
+  .attendee-chip {
+    background: white;
+    border-color: #e3e9f0;
+  }
+}
+
+// Variant C — "Krachtig": solid color-blocked group headers (mini versions
+// of the date tile), white body. Maximum scannability, heaviest look.
+.design-c {
+  .event-panel {
+    border-color: color-mix(in srgb, var(--slot-color) 40%, white);
+    border-left-width: 1px;
+  }
+
+  .event-panel-header {
+    background: var(--slot-color);
+    border-bottom: none;
+
+    .event-name {
+      color: white;
+    }
+  }
+
+  .event-slot-tag {
+    background: rgba(255, 255, 255, 0.22);
+    border-color: transparent;
+    color: white;
+  }
+
+  // The red sign-up button clashes on colored headers; invert it there.
+  .event-panel-header .btn.btn-signup {
+    background: white;
+    border-color: white;
+    color: var(--slot-color);
+
+    &:hover {
+      background: #f1f4f7;
+    }
+
+    &.is-signedup {
+      color: #2f7d5b;
+    }
+  }
+}

--- a/src/pages/leden/inschrijven-training/components/TrainingCard.scss
+++ b/src/pages/leden/inschrijven-training/components/TrainingCard.scss
@@ -1,0 +1,506 @@
+@import "../../../../variables";
+
+$day_ma: $dodeka_blauw;
+$day_wo: $dodeka_rood;
+$day_za: #2f7d5b;
+$day_other: #5d6f80;
+$groen: #2f7d5b;
+
+.training-card {
+  --day-color: #{$day_other};
+  background: white;
+  border: 1px solid #e3e8ee;
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0, 31, 72, 0.07);
+  transition: box-shadow 0.15s ease;
+
+  &.day-ma {
+    --day-color: #{$day_ma};
+  }
+  &.day-wo {
+    --day-color: #{$day_wo};
+  }
+  &.day-za {
+    --day-color: #{$day_za};
+  }
+
+  &:not(.is-cancelled):hover {
+    box-shadow: 0 4px 14px rgba(0, 31, 72, 0.13);
+  }
+
+  &.is-cancelled {
+    opacity: 0.75;
+    background: #f6f7f9;
+
+    .card-date {
+      background: repeating-linear-gradient(
+        -45deg,
+        var(--day-color),
+        var(--day-color) 8px,
+        color-mix(in srgb, var(--day-color) 82%, white) 8px,
+        color-mix(in srgb, var(--day-color) 82%, white) 16px
+      );
+    }
+
+    .card-weekday,
+    .card-daynum {
+      text-decoration: line-through;
+    }
+  }
+}
+
+.card-header {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  gap: 1rem;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+}
+
+.card-date {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 7rem;
+  padding: 0.9rem 0.5rem;
+  background: var(--day-color);
+  color: white;
+
+  .card-weekday {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    opacity: 0.85;
+  }
+
+  .card-daynum {
+    font-size: 1.35rem;
+    font-weight: $bold;
+    line-height: 1.6rem;
+  }
+
+  @include respond(phone) {
+    width: 5.2rem;
+
+    .card-daynum {
+      font-size: 1.1rem;
+    }
+  }
+}
+
+.card-summary {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.2rem;
+  padding: 0.7rem 0;
+
+  .card-time {
+    color: $dodeka_blauw;
+    font-weight: $bold;
+    font-size: 0.95rem;
+  }
+
+  .card-events {
+    color: #5d6f80;
+    font-size: 0.9rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .card-cancel-reason {
+    color: $dodeka_rood;
+    font-weight: $bold;
+  }
+}
+
+.card-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding-right: 1rem;
+
+  .card-count {
+    color: #5d6f80;
+    font-size: 0.85rem;
+    white-space: nowrap;
+
+    @include respond(phone) {
+      display: none;
+    }
+  }
+
+  .card-chevron {
+    color: #93a3b1;
+    transition: transform 0.15s ease;
+  }
+}
+
+.training-card.is-open .card-chevron {
+  transform: rotate(180deg);
+}
+
+.badge {
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: $bold;
+  white-space: nowrap;
+
+  &.badge-signedup {
+    background: color-mix(in srgb, $groen 14%, white);
+    color: $groen;
+    border: 1px solid color-mix(in srgb, $groen 40%, white);
+  }
+
+  &.badge-cancelled {
+    background: color-mix(in srgb, $dodeka_rood 12%, white);
+    color: $dodeka_rood;
+    border: 1px solid color-mix(in srgb, $dodeka_rood 40%, white);
+  }
+}
+
+.card-body {
+  border-top: 1px solid #edf0f4;
+  padding: 0.6rem 1rem 0.9rem;
+
+  .card-cancelled-text {
+    color: $dodeka_blauw;
+    margin: 0.5rem 0;
+  }
+}
+
+// One container listing all trainers of the day.
+.card-trainer-info {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem 0.8rem;
+  margin: 0.5rem 0 0.2rem;
+  padding: 0.45rem 0.7rem;
+  background: #f1f4f7;
+  border-radius: 8px;
+  color: $dodeka_blauw;
+  font-size: 0.9rem;
+}
+
+.trainer-info-label {
+  font-size: 0.68rem;
+  font-weight: $bold;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: #93a3b1;
+}
+
+.trainer-chips {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.trainer-chip {
+  display: inline-flex;
+  align-items: center;
+  background: white;
+  border: 1px solid #d4dbe3;
+  border-radius: 999px;
+  padding: 0.14rem 0.65rem;
+  font-size: 0.85rem;
+  color: $dodeka_blauw;
+
+  // Warming-up trainers are marked in baan-rood.
+  &.is-warmup {
+    border-color: $baan_rood;
+    color: $baan_rood;
+  }
+
+  // The contact point of the day is marked in TU blauw and takes priority
+  // over the warming-up color if both apply.
+  &.is-contact {
+    border-color: $tu_blauw;
+    color: $tu_blauw;
+    font-weight: $bold;
+  }
+}
+
+.card-trainer-info-edit {
+  gap: 0.6rem 1.4rem;
+}
+
+.trainer-edit-field {
+  flex: 1;
+  min-width: 14rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.75rem;
+  font-weight: $bold;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #5d6f80;
+
+  i {
+    font-weight: $normal;
+    text-transform: none;
+    letter-spacing: normal;
+  }
+
+  input {
+    font: inherit;
+    font-size: 0.85rem;
+    font-weight: $normal;
+    text-transform: none;
+    letter-spacing: normal;
+    color: $dodeka_blauw;
+    border: 1px solid #b7c3cf;
+    border-radius: 6px;
+    padding: 0.25rem 0.5rem;
+    background: white;
+  }
+}
+
+// --- Event rows -------------------------------------------------------------
+
+.event-list {
+  list-style: none;
+  margin: 0.4rem 0 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.5rem;
+
+  // Two columns on wide screens halves the scroll distance of an open day.
+  @include respond(computerscherm) {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.event-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  background: #fafbfd;
+  border: 1px solid #e8edf3;
+  border-radius: 10px;
+  padding: 0.45rem 0.65rem 0.55rem;
+}
+
+.event-head {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+
+  .event-name {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: $dodeka_blauw;
+    font-weight: $bold;
+    font-size: 1.05rem;
+  }
+
+  .event-name-input {
+    flex: 1;
+    font: inherit;
+    font-weight: $bold;
+    color: $dodeka_blauw;
+    border: 1px dashed #b7c3cf;
+    border-radius: 6px;
+    padding: 0.15rem 0.4rem;
+    max-width: 13rem;
+  }
+
+  .event-count {
+    color: #5d6f80;
+    font-size: 0.85rem;
+    background: #f1f4f7;
+    border-radius: 999px;
+    padding: 0.15rem 0.55rem;
+  }
+}
+
+.event-slot-tag {
+  font-size: 0.7rem;
+  font-weight: $bold;
+  letter-spacing: 0.05em;
+  color: #5d6f80;
+  background: #f1f4f7;
+  border-radius: 4px;
+  padding: 0.1rem 0.35rem;
+}
+
+
+.event-detail {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.event-comment {
+  margin: 0;
+  background: #fdf3e4;
+  color: #6b4a17;
+  border-radius: 6px;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.85rem;
+}
+
+.event-schedule {
+  background: white;
+  border: 1px solid #e3e8ee;
+  border-left: 3px solid var(--day-color);
+  border-radius: 8px;
+  padding: 0.45rem 0.7rem;
+
+  pre {
+    margin: 0;
+    font: inherit;
+    font-size: 0.88rem;
+    line-height: 1.4;
+    color: $dodeka_blauw;
+    white-space: pre-wrap;
+  }
+}
+
+.event-no-schedule,
+.event-no-attendees {
+  margin: 0;
+  color: #93a3b1;
+  font-size: 0.9rem;
+  font-style: italic;
+}
+
+.event-edit-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: #5d6f80;
+
+  textarea,
+  input {
+    font: inherit;
+    font-size: 0.9rem;
+    text-transform: none;
+    letter-spacing: normal;
+    color: $dodeka_blauw;
+    border: 1px solid #b7c3cf;
+    border-radius: 8px;
+    padding: 0.4rem 0.6rem;
+    resize: vertical;
+    background: white;
+  }
+}
+
+.event-attendees {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  background: white;
+  border: 1px solid #e8edf3;
+  border-radius: 8px;
+  padding: 0.35rem 0.55rem 0.45rem;
+}
+
+.event-attendees-label {
+  font-size: 0.68rem;
+  font-weight: $bold;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: #93a3b1;
+}
+
+.attendee-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.attendee-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  background: #f1f4f7;
+  color: $dodeka_blauw;
+  border-radius: 999px;
+  padding: 0.12rem 0.55rem;
+  font-size: 0.8rem;
+
+  &.is-you {
+    background: color-mix(in srgb, $groen 14%, white);
+    border: 1px solid color-mix(in srgb, $groen 40%, white);
+    font-weight: $bold;
+  }
+
+  .attendee-remove {
+    border: none;
+    background: none;
+    color: $dodeka_rood;
+    font-size: 1.05rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 0.1rem;
+
+    &:hover {
+      transform: scale(1.2);
+    }
+  }
+}
+
+// --- Manage footer ------------------------------------------------------------
+
+.card-manage-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  margin-top: 0.7rem;
+  padding-top: 0.7rem;
+  border-top: 1px dashed #d4dbe3;
+}
+
+.manage-cancel-form {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  input {
+    font: inherit;
+    font-size: 0.9rem;
+    border: 1px solid #b7c3cf;
+    border-radius: 8px;
+    padding: 0.35rem 0.6rem;
+  }
+}
+
+.manage-cancel-form input {
+  width: 16rem;
+
+  @include respond(phone) {
+    width: 10rem;
+  }
+}

--- a/src/pages/leden/inschrijven-training/components/TrainingCard.scss
+++ b/src/pages/leden/inschrijven-training/components/TrainingCard.scss
@@ -6,12 +6,22 @@ $day_za: #2f7d5b;
 $day_other: #5d6f80;
 $groen: #2f7d5b;
 
+// Each group keeps its own accent color across every training day — this is
+// the main separator between events (the day-color is reserved for "which
+// day", these are "which group"). Picked to stay clear of the day colors
+// above and the trainer highlight colors ($tu_blauw / $baan_rood).
+$slot_sprint: #d97706;
+$slot_mila: #0f9488;
+$slot_loopgroep: #6d4aa0;
+$slot_t1: #5b7290;
+$slot_t2: #a3456b;
+
 .training-card {
   --day-color: #{$day_other};
   background: white;
   border: 1px solid #e3e8ee;
   border-radius: 14px;
-  overflow: hidden;
+  // No overflow: hidden here — it would break the sticky card header.
   box-shadow: 0 1px 3px rgba(0, 31, 72, 0.07);
   transition: box-shadow 0.15s ease;
 
@@ -57,10 +67,41 @@ $groen: #2f7d5b;
   gap: 1rem;
   padding: 0;
   border: none;
-  background: none;
+  background: white;
   cursor: pointer;
   text-align: left;
   font: inherit;
+  // Clips the colored date tile to the card's rounded corners.
+  border-radius: 13px;
+  overflow: hidden;
+}
+
+// Zero-height marker just above the header; TrainingCard.tsx watches it with
+// an IntersectionObserver to know whether the sticky header is currently
+// pinned (see .is-stuck below).
+.card-sticky-sentinel {
+  height: 0;
+}
+
+// While a day is open, its header (with the date) sticks below the navbar
+// (4rem tall, z-index 10) so you always see which day you're scrolling in.
+.training-card.is-open > .card-header {
+  position: sticky;
+  top: 4rem;
+  z-index: 5;
+  border-radius: 13px 13px 0 0;
+  box-shadow: 0 3px 8px rgba(0, 31, 72, 0.08);
+
+  // Once actually pinned below the navbar, square off the top corners —
+  // rounded corners floating flush against the navbar look like a stray
+  // notch instead of a clean edge.
+  &.is-stuck {
+    border-radius: 0;
+  }
+}
+
+.training-card.is-cancelled > .card-header {
+  background: #f6f7f9;
 }
 
 .card-date {
@@ -181,18 +222,29 @@ $groen: #2f7d5b;
   }
 }
 
-// One container listing all trainers of the day.
+// One container listing all trainers of the day. Sticks directly below the
+// card header (see the inline `top` style, set from the measured header
+// height) so it joins the sticky header as one continuous block once you
+// scroll past it, instead of popping in as a separate element.
 .card-trainer-info {
+  position: sticky;
+  z-index: 4;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 0.4rem 0.8rem;
-  margin: 0.5rem 0 0.2rem;
+  margin: 0 0 0.5rem;
   padding: 0.45rem 0.7rem;
   background: #f1f4f7;
   border-radius: 8px;
   color: $dodeka_blauw;
   font-size: 0.9rem;
+
+  // Once actually pinned flush below the (also squared-off) header, drop
+  // the rounding so the two line up as one continuous bar.
+  &.is-stuck {
+    border-radius: 0;
+  }
 }
 
 .trainer-info-label {
@@ -273,39 +325,73 @@ $groen: #2f7d5b;
   }
 }
 
-// --- Event rows -------------------------------------------------------------
+// --- Event panels -------------------------------------------------------------
 
-.event-list {
-  list-style: none;
-  margin: 0.4rem 0 0;
-  padding: 0;
+// Running groups (with schedules) left, technical slots right on desktop;
+// a single stacked column on mobile.
+.event-columns {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 0.5rem;
+  gap: 0.6rem;
+  margin-top: 0.4rem;
 
-  // Two columns on wide screens halves the scroll distance of an open day.
   @include respond(computerscherm) {
     grid-template-columns: 1fr 1fr;
+    align-items: start;
   }
 }
 
-.event-row {
+.event-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  background: #fafbfd;
-  border: 1px solid #e8edf3;
-  border-radius: 10px;
-  padding: 0.45rem 0.65rem 0.55rem;
+  gap: 0.85rem;
 }
 
-.event-head {
+// Each group is a clearly bounded panel: a colored left accent bar and
+// tinted header strip identify the group, body holds schedule and
+// attendees. The accent color is per-group (not per-day) so e.g. every
+// Sprint panel looks the same regardless of which day it's on.
+.event-panel {
+  --slot-color: #{$day_other};
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #d5dce4;
+  border-left: 4px solid var(--slot-color);
+  border-radius: 10px;
+  background: white;
+  overflow: hidden;
+  box-shadow: 0 1px 2px rgba(0, 31, 72, 0.05);
+
+  &.event-panel-sprint {
+    --slot-color: #{$slot_sprint};
+  }
+  &.event-panel-mila {
+    --slot-color: #{$slot_mila};
+  }
+  &.event-panel-loopgroep {
+    --slot-color: #{$slot_loopgroep};
+  }
+  &.event-panel-t1 {
+    --slot-color: #{$slot_t1};
+  }
+  &.event-panel-t2 {
+    --slot-color: #{$slot_t2};
+  }
+}
+
+.event-panel-header {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 0.6rem;
+  padding: 0.5rem 0.7rem;
+  background: color-mix(in srgb, var(--slot-color) 13%, white);
+  border-bottom: 1px solid color-mix(in srgb, var(--slot-color) 30%, white);
 
   .event-name {
-    flex: 1;
     min-width: 0;
     display: flex;
     align-items: center;
@@ -324,14 +410,7 @@ $groen: #2f7d5b;
     border-radius: 6px;
     padding: 0.15rem 0.4rem;
     max-width: 13rem;
-  }
-
-  .event-count {
-    color: #5d6f80;
-    font-size: 0.85rem;
-    background: #f1f4f7;
-    border-radius: 999px;
-    padding: 0.15rem 0.55rem;
+    background: white;
   }
 }
 
@@ -340,17 +419,18 @@ $groen: #2f7d5b;
   font-weight: $bold;
   letter-spacing: 0.05em;
   color: #5d6f80;
-  background: #f1f4f7;
+  background: white;
+  border: 1px solid #dbe2ea;
   border-radius: 4px;
   padding: 0.1rem 0.35rem;
 }
 
-
-.event-detail {
+.event-panel-body {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.45rem;
+  padding: 0.55rem 0.7rem 0.65rem;
 }
 
 .event-comment {
@@ -363,9 +443,9 @@ $groen: #2f7d5b;
 }
 
 .event-schedule {
-  background: white;
+  background: #fbfcfd;
   border: 1px solid #e3e8ee;
-  border-left: 3px solid var(--day-color);
+  border-left: 3px solid var(--slot-color);
   border-radius: 8px;
   padding: 0.45rem 0.7rem;
 
@@ -416,10 +496,9 @@ $groen: #2f7d5b;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  background: white;
-  border: 1px solid #e8edf3;
+  background: #f4f6f9;
   border-radius: 8px;
-  padding: 0.35rem 0.55rem 0.45rem;
+  padding: 0.4rem 0.6rem 0.5rem;
 }
 
 .event-attendees-label {
@@ -443,7 +522,8 @@ $groen: #2f7d5b;
   display: inline-flex;
   align-items: center;
   gap: 0.3rem;
-  background: #f1f4f7;
+  background: white;
+  border: 1px solid #e3e9f0;
   color: $dodeka_blauw;
   border-radius: 999px;
   padding: 0.12rem 0.55rem;

--- a/src/pages/leden/inschrijven-training/components/TrainingCard.tsx
+++ b/src/pages/leden/inschrijven-training/components/TrainingCard.tsx
@@ -1,0 +1,439 @@
+import { useState } from "react";
+import type { Attendee, TrainingDay, TrainingEvent } from "../types";
+import {
+  dayColorClass,
+  formatDayMonth,
+  formatWeekday,
+  splitNames,
+} from "../utils";
+import "./TrainingCard.scss";
+
+interface TrainingCardProps {
+  training: TrainingDay;
+  currentUser: Attendee;
+  expanded: boolean;
+  onToggle: () => void;
+  manageMode: boolean;
+  onSignup: (eventId: string) => void;
+  onRemoveAttendee: (eventId: string, userId: string) => void;
+  onUpdate: (update: (training: TrainingDay) => TrainingDay) => void;
+  onDelete: () => void;
+}
+
+// The three running groups always have a schedule; the technical slots
+// (t1/t2) never do.
+function hasSchedule(event: TrainingEvent): boolean {
+  return event.slot !== "t1" && event.slot !== "t2";
+}
+
+function updateEvent(
+  training: TrainingDay,
+  eventId: string,
+  update: (event: TrainingEvent) => TrainingEvent,
+): TrainingDay {
+  return {
+    ...training,
+    events: training.events.map((event) =>
+      event.event_id === eventId ? update(event) : event,
+    ),
+  };
+}
+
+export default function TrainingCard(props: TrainingCardProps) {
+  const { training, currentUser, manageMode } = props;
+  const [cancelReason, setCancelReason] = useState("");
+  const [showCancelForm, setShowCancelForm] = useState(false);
+
+  const cancelled = training.cancelled !== null;
+  // The event the current user is signed up for on this day, if any.
+  const signedUpEvent = training.events.find((event) =>
+    event.attendees.some((a) => a.user_id === currentUser.user_id),
+  );
+  const totalAttendees = training.events.reduce(
+    (sum, event) => sum + event.attendees.length,
+    0,
+  );
+  // Members only see slots that have an event; managers see all five so
+  // they can fill in the technical slots.
+  const visibleEvents = training.events.filter(
+    (event) => manageMode || event.name !== null,
+  );
+
+  function cancelDay() {
+    const reason = cancelReason.trim();
+    if (reason === "") return;
+    props.onUpdate((t) => ({ ...t, cancelled: { reason } }));
+    setShowCancelForm(false);
+    setCancelReason("");
+  }
+
+  return (
+    <article
+      className={[
+        "training-card",
+        dayColorClass(training.date),
+        cancelled ? "is-cancelled" : "",
+        props.expanded ? "is-open" : "",
+      ].join(" ")}
+    >
+      <button className="card-header" onClick={props.onToggle}>
+        <div className="card-date">
+          <span className="card-weekday">{formatWeekday(training.date)}</span>
+          <span className="card-daynum">{formatDayMonth(training.date)}</span>
+        </div>
+        <div className="card-summary">
+          {cancelled ? (
+            <span className="card-cancel-reason">
+              Afgelast: {training.cancelled?.reason}
+            </span>
+          ) : (
+            <>
+              <span className="card-time">
+                {training.start_time}
+                {training.end_time ? ` – ${training.end_time}` : ""}
+              </span>
+              <span className="card-events">
+                {training.events
+                  .map((event) => event.name)
+                  .filter((name) => name !== null)
+                  .join(" · ")}
+              </span>
+            </>
+          )}
+        </div>
+        <div className="card-meta">
+          {signedUpEvent && !cancelled && (
+            <span className="badge badge-signedup">
+              ✓ Ingeschreven{signedUpEvent.name ? ` · ${signedUpEvent.name}` : ""}
+            </span>
+          )}
+          {cancelled && <span className="badge badge-cancelled">Afgelast</span>}
+          {!cancelled && (
+            <span className="card-count">{totalAttendees} aanmeldingen</span>
+          )}
+          <span className="card-chevron" aria-hidden>
+            ▾
+          </span>
+        </div>
+      </button>
+
+      {props.expanded && (
+        <div className="card-body">
+          {cancelled ? (
+            <p className="card-cancelled-text">
+              Deze training gaat niet door vanwege{" "}
+              <b>{training.cancelled?.reason}</b>.
+            </p>
+          ) : (
+            <>
+              <TrainerPanel
+                training={training}
+                manageMode={manageMode}
+                onUpdate={props.onUpdate}
+              />
+              <ul className="event-list">
+                {visibleEvents.map((event) => (
+                  <EventRow
+                    key={event.event_id}
+                    event={event}
+                    currentUser={currentUser}
+                    manageMode={manageMode}
+                    onSignup={() => props.onSignup(event.event_id)}
+                    onRemoveAttendee={(userId) =>
+                      props.onRemoveAttendee(event.event_id, userId)
+                    }
+                    onRename={(name) =>
+                      props.onUpdate((t) =>
+                        updateEvent(t, event.event_id, (ev) => ({
+                          ...ev,
+                          name: name.trim() === "" ? null : name,
+                        })),
+                      )
+                    }
+                    onEditComment={(comment) =>
+                      props.onUpdate((t) =>
+                        updateEvent(t, event.event_id, (ev) => ({
+                          ...ev,
+                          comment: comment.trim() === "" ? null : comment,
+                        })),
+                      )
+                    }
+                    onEditSchedule={(schedule) =>
+                      props.onUpdate((t) =>
+                        updateEvent(t, event.event_id, (ev) => ({
+                          ...ev,
+                          schedule: schedule.trim() === "" ? null : schedule,
+                        })),
+                      )
+                    }
+                  />
+                ))}
+              </ul>
+            </>
+          )}
+
+          {manageMode && (
+            <div className="card-manage-footer">
+              <button
+                className="btn btn-small btn-ghost"
+                onClick={props.onDelete}
+              >
+                Verwijderen
+              </button>
+              {cancelled ? (
+                <button
+                  className="btn btn-small"
+                  onClick={() =>
+                    props.onUpdate((t) => ({ ...t, cancelled: null }))
+                  }
+                >
+                  Training herstellen
+                </button>
+              ) : showCancelForm ? (
+                <div className="manage-cancel-form">
+                  <input
+                    type="text"
+                    placeholder="Reden van afgelasting…"
+                    value={cancelReason}
+                    onChange={(e) => setCancelReason(e.target.value)}
+                    onKeyDown={(e) => e.key === "Enter" && cancelDay()}
+                    autoFocus
+                  />
+                  <button
+                    className="btn btn-small btn-danger"
+                    onClick={cancelDay}
+                  >
+                    Afgelasten
+                  </button>
+                  <button
+                    className="btn btn-small btn-ghost"
+                    onClick={() => setShowCancelForm(false)}
+                  >
+                    Terug
+                  </button>
+                </div>
+              ) : (
+                <button
+                  className="btn btn-small btn-danger"
+                  onClick={() => setShowCancelForm(true)}
+                >
+                  Training afgelasten
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </article>
+  );
+}
+
+// One container with all five trainers of the day. The first name in the
+// list is the contact point and is highlighted; warm-up trainers get a tag.
+function TrainerPanel(props: {
+  training: TrainingDay;
+  manageMode: boolean;
+  onUpdate: (update: (training: TrainingDay) => TrainingDay) => void;
+}) {
+  const { training, manageMode } = props;
+  const trainerNames = splitNames(training.trainers);
+  const warmupNames = splitNames(training.warmup_trainers);
+  // Warm-up trainers that are not in the trainer list still get a chip.
+  const extraWarmup = warmupNames.filter(
+    (name) => !trainerNames.includes(name),
+  );
+
+  if (manageMode) {
+    return (
+      <div className="card-trainer-info card-trainer-info-edit">
+        <label className="trainer-edit-field">
+          Trainers <i>(eerste naam is het aanspreekpunt)</i>
+          <input
+            type="text"
+            value={training.trainers ?? ""}
+            placeholder="Jasmijn, Karel, Roos, Sven, Nina"
+            onChange={(e) =>
+              props.onUpdate((t) => ({
+                ...t,
+                trainers:
+                  e.target.value.trim() === "" ? null : e.target.value,
+              }))
+            }
+          />
+        </label>
+        <label className="trainer-edit-field">
+          Warming-up
+          <input
+            type="text"
+            value={training.warmup_trainers ?? ""}
+            placeholder="Wie geeft de warming-up?"
+            onChange={(e) =>
+              props.onUpdate((t) => ({
+                ...t,
+                warmup_trainers:
+                  e.target.value.trim() === "" ? null : e.target.value,
+              }))
+            }
+          />
+        </label>
+      </div>
+    );
+  }
+
+  if (trainerNames.length === 0 && extraWarmup.length === 0) return null;
+
+  return (
+    <div className="card-trainer-info">
+      <span className="trainer-info-label">Trainers</span>
+      <ul className="trainer-chips">
+        {trainerNames.map((name, i) => (
+          <li
+            key={name}
+            className={[
+              "trainer-chip",
+              i === 0 ? "is-contact" : "",
+              warmupNames.includes(name) ? "is-warmup" : "",
+            ].join(" ")}
+            title={
+              i === 0
+                ? "Aanspreekpunt"
+                : warmupNames.includes(name)
+                  ? "Warming-up"
+                  : undefined
+            }
+          >
+            {name}
+          </li>
+        ))}
+        {extraWarmup.map((name) => (
+          <li key={name} className="trainer-chip is-warmup" title="Warming-up">
+            {name}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+interface EventRowProps {
+  event: TrainingEvent;
+  currentUser: Attendee;
+  manageMode: boolean;
+  onSignup: () => void;
+  onRemoveAttendee: (userId: string) => void;
+  onRename: (name: string) => void;
+  onEditComment: (comment: string) => void;
+  onEditSchedule: (schedule: string) => void;
+}
+
+function EventRow(props: EventRowProps) {
+  const { event, manageMode } = props;
+  const isTechnical = !hasSchedule(event);
+  const isSignedUp = event.attendees.some(
+    (a) => a.user_id === props.currentUser.user_id,
+  );
+
+  return (
+    <li className="event-row">
+      <div className="event-head">
+        {manageMode && isTechnical ? (
+          <input
+            className="event-name-input"
+            type="text"
+            value={event.name ?? ""}
+            placeholder={`${event.slot.toUpperCase()}-onderdeel…`}
+            onChange={(e) => props.onRename(e.target.value)}
+          />
+        ) : (
+          <span className="event-name">
+            {event.name}
+            {isTechnical && (
+              <span className="event-slot-tag">{event.slot.toUpperCase()}</span>
+            )}
+          </span>
+        )}
+        <span className="event-count">{event.attendees.length}</span>
+        {!manageMode && event.name !== null && (
+          <button
+            className={`btn btn-signup ${isSignedUp ? "is-signedup" : ""}`}
+            onClick={props.onSignup}
+          >
+            {isSignedUp ? "✓ Ingeschreven" : "Inschrijven"}
+          </button>
+        )}
+      </div>
+
+      <div className="event-detail">
+        {manageMode ? (
+          <>
+            {!isTechnical && (
+              <label className="event-edit-label">
+                Trainingsschema
+                <textarea
+                  rows={4}
+                  value={event.schedule ?? ""}
+                  placeholder="Schema voor dit onderdeel…"
+                  onChange={(e) => props.onEditSchedule(e.target.value)}
+                />
+              </label>
+            )}
+            <label className="event-edit-label">
+              Opmerking
+              <textarea
+                rows={2}
+                value={event.comment ?? ""}
+                placeholder="Bijv. neem spikes mee…"
+                onChange={(e) => props.onEditComment(e.target.value)}
+              />
+            </label>
+          </>
+        ) : (
+          <>
+            {event.comment && (
+              <p className="event-comment">💬 {event.comment}</p>
+            )}
+            {!isTechnical &&
+              (event.schedule ? (
+                <div className="event-schedule">
+                  <pre>{event.schedule}</pre>
+                </div>
+              ) : (
+                <p className="event-no-schedule">
+                  Nog geen schema beschikbaar.
+                </p>
+              ))}
+          </>
+        )}
+
+        {event.attendees.length > 0 && (
+          <div className="event-attendees">
+            <span className="event-attendees-label">Aanmeldingen</span>
+            <ul className="attendee-list">
+              {event.attendees.map((attendee) => (
+                <li
+                  key={attendee.user_id}
+                  className={`attendee-chip ${
+                    attendee.user_id === props.currentUser.user_id
+                      ? "is-you"
+                      : ""
+                  }`}
+                >
+                  {attendee.name}
+                  {manageMode && (
+                    <button
+                      className="attendee-remove"
+                      title="Verwijder van training (niet aanwezig)"
+                      onClick={() => props.onRemoveAttendee(attendee.user_id)}
+                    >
+                      ×
+                    </button>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/src/pages/leden/inschrijven-training/components/TrainingCard.tsx
+++ b/src/pages/leden/inschrijven-training/components/TrainingCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Attendee, TrainingDay, TrainingEvent } from "../types";
 import {
   dayColorClass,
@@ -7,6 +7,10 @@ import {
   splitNames,
 } from "../utils";
 import "./TrainingCard.scss";
+
+// The navbar (position: sticky, top: 0) is 4rem tall, so the card header
+// sticks right below it at this offset.
+const STICKY_OFFSET_PX = 64;
 
 interface TrainingCardProps {
   training: TrainingDay;
@@ -43,6 +47,45 @@ export default function TrainingCard(props: TrainingCardProps) {
   const { training, currentUser, manageMode } = props;
   const [cancelReason, setCancelReason] = useState("");
   const [showCancelForm, setShowCancelForm] = useState(false);
+  const [isStuck, setIsStuck] = useState(false);
+  const [headerHeight, setHeaderHeight] = useState(0);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const headerRef = useRef<HTMLButtonElement>(null);
+
+  // Detects whether the sticky header is actually pinned below the navbar
+  // right now (as opposed to sitting in its normal in-flow position), so we
+  // can square off its corners only while it's floating over other cards.
+  useEffect(() => {
+    if (!props.expanded) {
+      setIsStuck(false);
+      return;
+    }
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry) setIsStuck(entry.intersectionRatio < 1);
+      },
+      { threshold: [1], rootMargin: `-${STICKY_OFFSET_PX + 1}px 0px 0px 0px` },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [props.expanded]);
+
+  // Measures the header so the trainer panel right below it can stick at
+  // exactly that offset — it joins the header as one continuous sticky
+  // stack instead of popping in as a separate element (which felt jumpy).
+  useEffect(() => {
+    if (!props.expanded) return;
+    const header = headerRef.current;
+    if (!header) return;
+    const observer = new ResizeObserver(([entry]) => {
+      if (entry) setHeaderHeight(entry.borderBoxSize[0]?.blockSize ?? entry.contentRect.height);
+    });
+    observer.observe(header);
+    return () => observer.disconnect();
+  }, [props.expanded]);
 
   const cancelled = training.cancelled !== null;
   // The event the current user is signed up for on this day, if any.
@@ -58,6 +101,10 @@ export default function TrainingCard(props: TrainingCardProps) {
   const visibleEvents = training.events.filter(
     (event) => manageMode || event.name !== null,
   );
+  // Desktop shows the running groups (with schedules) on the left and the
+  // technical slots on the right.
+  const runningEvents = visibleEvents.filter((event) => hasSchedule(event));
+  const technicalEvents = visibleEvents.filter((event) => !hasSchedule(event));
 
   function cancelDay() {
     const reason = cancelReason.trim();
@@ -65,6 +112,45 @@ export default function TrainingCard(props: TrainingCardProps) {
     props.onUpdate((t) => ({ ...t, cancelled: { reason } }));
     setShowCancelForm(false);
     setCancelReason("");
+  }
+
+  function renderEvent(event: TrainingEvent) {
+    return (
+      <EventPanel
+        key={event.event_id}
+        event={event}
+        currentUser={currentUser}
+        manageMode={manageMode}
+        onSignup={() => props.onSignup(event.event_id)}
+        onRemoveAttendee={(userId) =>
+          props.onRemoveAttendee(event.event_id, userId)
+        }
+        onRename={(name) =>
+          props.onUpdate((t) =>
+            updateEvent(t, event.event_id, (ev) => ({
+              ...ev,
+              name: name.trim() === "" ? null : name,
+            })),
+          )
+        }
+        onEditComment={(comment) =>
+          props.onUpdate((t) =>
+            updateEvent(t, event.event_id, (ev) => ({
+              ...ev,
+              comment: comment.trim() === "" ? null : comment,
+            })),
+          )
+        }
+        onEditSchedule={(schedule) =>
+          props.onUpdate((t) =>
+            updateEvent(t, event.event_id, (ev) => ({
+              ...ev,
+              schedule: schedule.trim() === "" ? null : schedule,
+            })),
+          )
+        }
+      />
+    );
   }
 
   return (
@@ -76,7 +162,12 @@ export default function TrainingCard(props: TrainingCardProps) {
         props.expanded ? "is-open" : "",
       ].join(" ")}
     >
-      <button className="card-header" onClick={props.onToggle}>
+      <div ref={sentinelRef} className="card-sticky-sentinel" aria-hidden />
+      <button
+        ref={headerRef}
+        className={`card-header ${isStuck ? "is-stuck" : ""}`}
+        onClick={props.onToggle}
+      >
         <div className="card-date">
           <span className="card-weekday">{formatWeekday(training.date)}</span>
           <span className="card-daynum">{formatDayMonth(training.date)}</span>
@@ -130,45 +221,19 @@ export default function TrainingCard(props: TrainingCardProps) {
                 training={training}
                 manageMode={manageMode}
                 onUpdate={props.onUpdate}
+                stickyTop={STICKY_OFFSET_PX + headerHeight}
+                isStuck={isStuck}
               />
-              <ul className="event-list">
-                {visibleEvents.map((event) => (
-                  <EventRow
-                    key={event.event_id}
-                    event={event}
-                    currentUser={currentUser}
-                    manageMode={manageMode}
-                    onSignup={() => props.onSignup(event.event_id)}
-                    onRemoveAttendee={(userId) =>
-                      props.onRemoveAttendee(event.event_id, userId)
-                    }
-                    onRename={(name) =>
-                      props.onUpdate((t) =>
-                        updateEvent(t, event.event_id, (ev) => ({
-                          ...ev,
-                          name: name.trim() === "" ? null : name,
-                        })),
-                      )
-                    }
-                    onEditComment={(comment) =>
-                      props.onUpdate((t) =>
-                        updateEvent(t, event.event_id, (ev) => ({
-                          ...ev,
-                          comment: comment.trim() === "" ? null : comment,
-                        })),
-                      )
-                    }
-                    onEditSchedule={(schedule) =>
-                      props.onUpdate((t) =>
-                        updateEvent(t, event.event_id, (ev) => ({
-                          ...ev,
-                          schedule: schedule.trim() === "" ? null : schedule,
-                        })),
-                      )
-                    }
-                  />
-                ))}
-              </ul>
+              <div className="event-columns">
+                <ul className="event-list">
+                  {runningEvents.map(renderEvent)}
+                </ul>
+                {technicalEvents.length > 0 && (
+                  <ul className="event-list event-list-technical">
+                    {technicalEvents.map(renderEvent)}
+                  </ul>
+                )}
+              </div>
             </>
           )}
 
@@ -230,10 +295,14 @@ export default function TrainingCard(props: TrainingCardProps) {
 
 // One container with all five trainers of the day. The first name in the
 // list is the contact point and is highlighted; warm-up trainers get a tag.
+// Sticks right below the card header once you scroll past it, so who's
+// training stays visible without a separate, jumpier sticky element.
 function TrainerPanel(props: {
   training: TrainingDay;
   manageMode: boolean;
   onUpdate: (update: (training: TrainingDay) => TrainingDay) => void;
+  stickyTop: number;
+  isStuck: boolean;
 }) {
   const { training, manageMode } = props;
   const trainerNames = splitNames(training.trainers);
@@ -245,7 +314,10 @@ function TrainerPanel(props: {
 
   if (manageMode) {
     return (
-      <div className="card-trainer-info card-trainer-info-edit">
+      <div
+        className={`card-trainer-info card-trainer-info-edit ${props.isStuck ? "is-stuck" : ""}`}
+        style={{ top: props.stickyTop }}
+      >
         <label className="trainer-edit-field">
           Trainers <i>(eerste naam is het aanspreekpunt)</i>
           <input
@@ -283,7 +355,10 @@ function TrainerPanel(props: {
   if (trainerNames.length === 0 && extraWarmup.length === 0) return null;
 
   return (
-    <div className="card-trainer-info">
+    <div
+      className={`card-trainer-info ${props.isStuck ? "is-stuck" : ""}`}
+      style={{ top: props.stickyTop }}
+    >
       <span className="trainer-info-label">Trainers</span>
       <ul className="trainer-chips">
         {trainerNames.map((name, i) => (
@@ -315,7 +390,7 @@ function TrainerPanel(props: {
   );
 }
 
-interface EventRowProps {
+interface EventPanelProps {
   event: TrainingEvent;
   currentUser: Attendee;
   manageMode: boolean;
@@ -326,7 +401,9 @@ interface EventRowProps {
   onEditSchedule: (schedule: string) => void;
 }
 
-function EventRow(props: EventRowProps) {
+// One group of the training day, as a clearly bounded panel: a tinted
+// header strip (name + sign-up), then schedule, then attendees.
+function EventPanel(props: EventPanelProps) {
   const { event, manageMode } = props;
   const isTechnical = !hasSchedule(event);
   const isSignedUp = event.attendees.some(
@@ -334,8 +411,8 @@ function EventRow(props: EventRowProps) {
   );
 
   return (
-    <li className="event-row">
-      <div className="event-head">
+    <li className={`event-panel event-panel-${event.slot}`}>
+      <div className="event-panel-header">
         {manageMode && isTechnical ? (
           <input
             className="event-name-input"
@@ -352,7 +429,6 @@ function EventRow(props: EventRowProps) {
             )}
           </span>
         )}
-        <span className="event-count">{event.attendees.length}</span>
         {!manageMode && event.name !== null && (
           <button
             className={`btn btn-signup ${isSignedUp ? "is-signedup" : ""}`}
@@ -363,7 +439,7 @@ function EventRow(props: EventRowProps) {
         )}
       </div>
 
-      <div className="event-detail">
+      <div className="event-panel-body">
         {manageMode ? (
           <>
             {!isTechnical && (
@@ -405,9 +481,13 @@ function EventRow(props: EventRowProps) {
           </>
         )}
 
-        {event.attendees.length > 0 && (
-          <div className="event-attendees">
-            <span className="event-attendees-label">Aanmeldingen</span>
+        <div className="event-attendees">
+          <span className="event-attendees-label">
+            Aanmeldingen ({event.attendees.length})
+          </span>
+          {event.attendees.length === 0 ? (
+            <span className="event-no-attendees">Nog geen aanmeldingen.</span>
+          ) : (
             <ul className="attendee-list">
               {event.attendees.map((attendee) => (
                 <li
@@ -431,8 +511,8 @@ function EventRow(props: EventRowProps) {
                 </li>
               ))}
             </ul>
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </li>
   );

--- a/src/pages/leden/inschrijven-training/inschrijven-training.scss
+++ b/src/pages/leden/inschrijven-training/inschrijven-training.scss
@@ -185,6 +185,11 @@ $day_za: #2f7d5b;
   position: fixed;
   bottom: 1rem;
   right: 1rem;
+
+  // The design-exploration pill sits above the "Bekijk als" pill.
+  &.training-design-switcher {
+    bottom: 3.6rem;
+  }
   z-index: 90;
   display: flex;
   align-items: center;

--- a/src/pages/leden/inschrijven-training/inschrijven-training.scss
+++ b/src/pages/leden/inschrijven-training/inschrijven-training.scss
@@ -1,0 +1,215 @@
+@import "../../../variables";
+
+$day_ma: $dodeka_blauw;
+$day_wo: $dodeka_rood;
+$day_za: #2f7d5b;
+
+.training-page {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 52rem;
+  min-width: 0;
+  margin: 0 auto;
+  padding: 0 $margin_x 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  @include respond(mobile) {
+    padding: 0 $margin_mobile 3rem;
+  }
+}
+
+.training-status {
+  text-align: center;
+  color: $dodeka_blauw;
+  margin: 2rem $margin_mobile;
+}
+
+.training-login {
+  display: flex;
+  justify-content: center;
+}
+
+.training-login-button {
+  font: inherit;
+  font-weight: $bold;
+  color: white;
+  background: $dodeka_rood;
+  border: none;
+  border-radius: 8px;
+  padding: 0.6rem 2rem;
+  cursor: pointer;
+}
+
+// --- Toolbar ----------------------------------------------------------------
+
+.training-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+}
+
+.training-legend {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.legend-chip {
+  font-size: 0.8rem;
+  font-weight: $bold;
+  color: white;
+  border-radius: 999px;
+  padding: 0.2rem 0.8rem;
+
+  &.legend-ma {
+    background: $day_ma;
+  }
+  &.legend-wo {
+    background: $day_wo;
+  }
+  &.legend-za {
+    background: $day_za;
+  }
+}
+
+.training-trainer-tools {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.training-add-day {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+  background: #f1f4f7;
+  border: 1px dashed #b7c3cf;
+  border-radius: 10px;
+  padding: 0.6rem 0.9rem;
+  color: $dodeka_blauw;
+  font-size: 0.95rem;
+
+  input[type="date"] {
+    font: inherit;
+    font-size: 0.9rem;
+    border: 1px solid #b7c3cf;
+    border-radius: 8px;
+    padding: 0.3rem 0.5rem;
+    background: white;
+  }
+}
+
+.training-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+// --- Buttons (shared by the page, cards and modal) ---------------------------
+
+.training-page,
+.import-overlay {
+  .btn {
+    font: inherit;
+    font-size: 0.95rem;
+    font-weight: $bold;
+    color: $dodeka_blauw;
+    background: white;
+    border: 1px solid #b7c3cf;
+    border-radius: 8px;
+    padding: 0.45rem 1rem;
+    cursor: pointer;
+    white-space: nowrap;
+    transition:
+      background 0.12s ease,
+      color 0.12s ease;
+
+    &:hover {
+      background: #f1f4f7;
+    }
+
+    &.btn-small {
+      font-size: 0.85rem;
+      padding: 0.3rem 0.8rem;
+    }
+
+    &.btn-primary {
+      background: $dodeka_blauw;
+      border-color: $dodeka_blauw;
+      color: white;
+
+      &:hover {
+        background: $dodeka_blauw90p;
+      }
+    }
+
+    &.btn-danger {
+      color: $dodeka_rood;
+      border-color: color-mix(in srgb, $dodeka_rood 45%, white);
+
+      &:hover {
+        background: color-mix(in srgb, $dodeka_rood 8%, white);
+      }
+    }
+
+    &.btn-ghost {
+      border-color: transparent;
+      color: #5d6f80;
+    }
+
+    &.btn-signup {
+      background: $dodeka_rood;
+      border-color: $dodeka_rood;
+      color: white;
+      font-size: 0.85rem;
+      padding: 0.3rem 0.9rem;
+
+      &:hover {
+        background: $baan_rood;
+      }
+
+      &.is-signedup {
+        background: #2f7d5b;
+        border-color: #2f7d5b;
+      }
+    }
+  }
+}
+
+// --- DEV view switcher --------------------------------------------------------
+
+.training-dev-switcher {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: 90;
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  background: $dodeka_blauw;
+  color: white;
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.8rem;
+  box-shadow: 0 4px 14px rgba(0, 31, 72, 0.35);
+
+  button {
+    font: inherit;
+    font-size: 0.8rem;
+    color: white;
+    background: none;
+    border: 1px solid transparent;
+    border-radius: 999px;
+    padding: 0.15rem 0.6rem;
+    cursor: pointer;
+
+    &.is-active {
+      background: white;
+      color: $dodeka_blauw;
+      font-weight: $bold;
+    }
+  }
+}

--- a/src/pages/leden/inschrijven-training/inschrijven-training.tsx
+++ b/src/pages/leden/inschrijven-training/inschrijven-training.tsx
@@ -1,0 +1,346 @@
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import { useSessionInfo } from "$functions/query.ts";
+import PageTitle from "$components/PageTitle.tsx";
+import type { Attendee, ImportedTraining, TrainingDay } from "./types";
+import { MOCK_USER, makeMockStandings, makeMockTrainings } from "./mock-data";
+import { toTrainingDay } from "./utils";
+import TrainingCard from "./components/TrainingCard";
+import CompetitionPanel from "./components/CompetitionPanel";
+import ImportModal from "./components/ImportModal";
+import "./inschrijven-training.scss";
+
+// Permission sets for the DEV-only "view as" switcher, so every view can be
+// tested without a backend.
+const DEV_VIEW_PERMISSIONS: Record<string, string[]> = {
+  Lid: ["member"],
+  Trainer: ["member", "trainers"],
+  Bestuur: ["member", "bestuur"],
+};
+
+function userInDay(training: TrainingDay, userId: string): boolean {
+  return training.events.some((event) =>
+    event.attendees.some((a) => a.user_id === userId),
+  );
+}
+
+function sortByDate(trainings: TrainingDay[]): TrainingDay[] {
+  return [...trainings].sort((a, b) => a.date.localeCompare(b.date));
+}
+
+export default function InschrijvenTraining() {
+  const navigate = useNavigate();
+  const { data: session, isLoading } = useSessionInfo();
+  const devMode = import.meta.env.DEV;
+
+  const [devView, setDevView] = useState("Lid");
+  const [trainings, setTrainings] = useState(() =>
+    sortByDate(makeMockTrainings()),
+  );
+  const [standings, setStandings] = useState(makeMockStandings);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [manageMode, setManageMode] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
+  const [newDate, setNewDate] = useState("");
+
+  if (isLoading && !devMode) {
+    return <PageTitle title="Inschrijven trainingen" />;
+  }
+
+  if (!session && !devMode) {
+    return (
+      <>
+        <PageTitle title="Inschrijven trainingen" />
+        <p className="training-status">
+          Deze pagina is helaas niet toegankelijk als je niet ingelogd bent.
+          Log in om deze pagina te kunnen bekijken.
+        </p>
+        <div className="training-login">
+          <button
+            onClick={() => navigate("/account/login")}
+            className="training-login-button"
+          >
+            Inloggen
+          </button>
+        </div>
+      </>
+    );
+  }
+
+  const permissions = devMode
+    ? (DEV_VIEW_PERMISSIONS[devView] ?? ["member"])
+    : (session?.user.permissions ?? []);
+  const isBoard =
+    permissions.includes("bestuur") || permissions.includes("admin");
+  const isTrainer = permissions.includes("trainers") || isBoard;
+  const isMember = permissions.includes("member") || isTrainer;
+
+  if (!isMember) {
+    return (
+      <>
+        <PageTitle title="Inschrijven trainingen" />
+        <p className="training-status">
+          Je hebt een actief lidmaatschap nodig om deze pagina te bekijken.
+        </p>
+      </>
+    );
+  }
+
+  const currentUser: Attendee = session
+    ? {
+        user_id: session.user.user_id,
+        name: `${session.user.firstname} ${session.user.lastname}`,
+      }
+    : MOCK_USER;
+
+  function adjustPoints(user: Attendee, delta: number) {
+    setStandings((prev) => {
+      const existing = prev.find((s) => s.user_id === user.user_id);
+      if (!existing) {
+        return delta > 0
+          ? [...prev, { user_id: user.user_id, name: user.name, points: delta }]
+          : prev;
+      }
+      return prev.map((s) =>
+        s.user_id === user.user_id
+          ? { ...s, points: Math.max(0, s.points + delta) }
+          : s,
+      );
+    });
+  }
+
+  // Sign the current user up for an event (or out, when already signed up).
+  // You join one event per training day: signing up for another event moves
+  // you. Competition points follow day attendance: +1 the first time you join
+  // a day, -1 when you leave it entirely.
+  function handleSignup(trainingId: string, eventId: string) {
+    const training = trainings.find((t) => t.training_id === trainingId);
+    if (!training || training.cancelled) return;
+
+    const wasInDay = userInDay(training, currentUser.user_id);
+    const wasInEvent = training.events
+      .find((e) => e.event_id === eventId)
+      ?.attendees.some((a) => a.user_id === currentUser.user_id);
+
+    const updated: TrainingDay = {
+      ...training,
+      events: training.events.map((event) => {
+        const attendees = event.attendees.filter(
+          (a) => a.user_id !== currentUser.user_id,
+        );
+        if (event.event_id === eventId && !wasInEvent) {
+          attendees.push({ ...currentUser });
+        }
+        return { ...event, attendees };
+      }),
+    };
+
+    setTrainings(
+      trainings.map((t) => (t.training_id === trainingId ? updated : t)),
+    );
+    const isInDay = userInDay(updated, currentUser.user_id);
+    if (!wasInDay && isInDay) adjustPoints(currentUser, 1);
+    if (wasInDay && !isInDay) adjustPoints(currentUser, -1);
+  }
+
+  // Trainer action: remove a no-show from an event (also retracts their
+  // competition point for this day).
+  function handleRemoveAttendee(
+    trainingId: string,
+    eventId: string,
+    userId: string,
+  ) {
+    const training = trainings.find((t) => t.training_id === trainingId);
+    const removed = training?.events
+      .find((e) => e.event_id === eventId)
+      ?.attendees.find((a) => a.user_id === userId);
+    if (!training || !removed) return;
+
+    const updated: TrainingDay = {
+      ...training,
+      events: training.events.map((event) =>
+        event.event_id === eventId
+          ? {
+              ...event,
+              attendees: event.attendees.filter((a) => a.user_id !== userId),
+            }
+          : event,
+      ),
+    };
+    setTrainings(
+      trainings.map((t) => (t.training_id === trainingId ? updated : t)),
+    );
+    if (!userInDay(updated, userId)) adjustPoints(removed, -1);
+  }
+
+  function retractDayPoints(training: TrainingDay) {
+    const seen = new Set<string>();
+    for (const event of training.events) {
+      for (const attendee of event.attendees) {
+        if (!seen.has(attendee.user_id)) {
+          seen.add(attendee.user_id);
+          adjustPoints(attendee, -1);
+        }
+      }
+    }
+  }
+
+  function handleDelete(trainingId: string) {
+    const training = trainings.find((t) => t.training_id === trainingId);
+    if (!training) return;
+    if (!window.confirm("Weet je zeker dat je deze training wilt verwijderen?")) {
+      return;
+    }
+    retractDayPoints(training);
+    setTrainings(trainings.filter((t) => t.training_id !== trainingId));
+  }
+
+  function handleAddTraining() {
+    if (!newDate) return;
+    if (trainings.some((t) => t.date === newDate)) {
+      window.alert("Er staat al een training op deze datum.");
+      return;
+    }
+    const added = toTrainingDay(
+      {
+        date: newDate,
+        sprint_schedule: null,
+        mila_schedule: null,
+        loopgroep_schedule: null,
+        t1_event: null,
+        t2_event: null,
+        available_trainers: null,
+        warmup_trainers: null,
+      },
+      `training_${newDate}`,
+    );
+    setTrainings(sortByDate([...trainings, added]));
+    setNewDate("");
+  }
+
+  function handleImport(
+    imported: ImportedTraining[],
+    replaceDates: string[],
+  ) {
+    const replaced = trainings.filter((t) => replaceDates.includes(t.date));
+    replaced.forEach(retractDayPoints);
+    const kept = trainings.filter((t) => !replaceDates.includes(t.date));
+    const added = imported.map((imp) =>
+      toTrainingDay(imp, `training_${imp.date}`),
+    );
+    setTrainings(sortByDate([...kept, ...added]));
+    setImportOpen(false);
+  }
+
+  return (
+    <>
+      <PageTitle title="Inschrijven trainingen" />
+      <div className="training-page">
+        <div className="training-toolbar">
+          <div className="training-legend">
+            <span className="legend-chip legend-ma">Maandag</span>
+            <span className="legend-chip legend-wo">Woensdag</span>
+            <span className="legend-chip legend-za">Zaterdag</span>
+          </div>
+          {isTrainer && (
+            <div className="training-trainer-tools">
+              <button
+                className="btn btn-small"
+                onClick={() => setImportOpen(true)}
+              >
+                Schema importeren
+              </button>
+              <button
+                className={`btn btn-small ${manageMode ? "btn-primary" : ""}`}
+                onClick={() => setManageMode(!manageMode)}
+              >
+                {manageMode ? "Beheren: aan" : "Beheren"}
+              </button>
+            </div>
+          )}
+        </div>
+
+        {manageMode && (
+          <div className="training-add-day">
+            <span>Nieuwe training:</span>
+            <input
+              type="date"
+              value={newDate}
+              onChange={(e) => setNewDate(e.target.value)}
+            />
+            <button className="btn btn-small" onClick={handleAddTraining}>
+              + Toevoegen
+            </button>
+          </div>
+        )}
+
+        {isBoard && <CompetitionPanel standings={standings} />}
+
+        <div className="training-list">
+          {trainings.map((training) => (
+            <TrainingCard
+              key={training.training_id}
+              training={training}
+              currentUser={currentUser}
+              expanded={expandedId === training.training_id}
+              onToggle={() =>
+                setExpandedId(
+                  expandedId === training.training_id
+                    ? null
+                    : training.training_id,
+                )
+              }
+              manageMode={manageMode && isTrainer}
+              onSignup={(eventId) =>
+                handleSignup(training.training_id, eventId)
+              }
+              onRemoveAttendee={(eventId, userId) =>
+                handleRemoveAttendee(training.training_id, eventId, userId)
+              }
+              onUpdate={(update) =>
+                setTrainings((prev) =>
+                  prev.map((t) =>
+                    t.training_id === training.training_id ? update(t) : t,
+                  ),
+                )
+              }
+              onDelete={() => handleDelete(training.training_id)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {importOpen && (
+        <ImportModal
+          existingDates={trainings.map((t) => t.date)}
+          onClose={() => setImportOpen(false)}
+          onImport={handleImport}
+        />
+      )}
+
+      {devMode && (
+        <div className="training-dev-switcher">
+          <span>Bekijk als:</span>
+          {Object.keys(DEV_VIEW_PERMISSIONS).map((view) => (
+            <button
+              key={view}
+              className={devView === view ? "is-active" : ""}
+              onClick={() => {
+                setDevView(view);
+                const perms = DEV_VIEW_PERMISSIONS[view] ?? [];
+                if (
+                  !perms.includes("trainers") &&
+                  !perms.includes("bestuur")
+                ) {
+                  setManageMode(false);
+                }
+              }}
+            >
+              {view}
+            </button>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/pages/leden/inschrijven-training/inschrijven-training.tsx
+++ b/src/pages/leden/inschrijven-training/inschrijven-training.tsx
@@ -2,7 +2,13 @@ import { useState } from "react";
 import { useNavigate } from "react-router";
 import { useSessionInfo } from "$functions/query.ts";
 import PageTitle from "$components/PageTitle.tsx";
-import type { Attendee, ImportedTraining, TrainingDay } from "./types";
+import type {
+  Attendee,
+  ImportedGroupSchedule,
+  ImportedTraining,
+  ScheduleSlot,
+  TrainingDay,
+} from "./types";
 import { MOCK_USER, makeMockStandings, makeMockTrainings } from "./mock-data";
 import { toTrainingDay } from "./utils";
 import TrainingCard from "./components/TrainingCard";
@@ -232,6 +238,59 @@ export default function InschrijvenTraining() {
     setImportOpen(false);
   }
 
+  // A trainer uploads all schedules for one group. Missing days are
+  // created with default times, empty schedules are filled in, and already
+  // filled schedules are only overwritten for dates the trainer chose.
+  function handleImportGroup(
+    slot: ScheduleSlot,
+    items: ImportedGroupSchedule[],
+    replaceDates: string[],
+  ) {
+    let next = [...trainings];
+    for (const item of items) {
+      const existing = next.find((t) => t.date === item.date);
+      if (!existing) {
+        const day = toTrainingDay(
+          {
+            date: item.date,
+            sprint_schedule: null,
+            mila_schedule: null,
+            loopgroep_schedule: null,
+            t1_event: null,
+            t2_event: null,
+            available_trainers: null,
+            warmup_trainers: null,
+          },
+          `training_${item.date}`,
+        );
+        day.events = day.events.map((event) =>
+          event.slot === slot ? { ...event, schedule: item.schedule } : event,
+        );
+        next.push(day);
+        continue;
+      }
+      const groupEvent = existing.events.find((e) => e.slot === slot);
+      const hasExistingSchedule = groupEvent?.schedule != null;
+      if (hasExistingSchedule && !replaceDates.includes(item.date)) {
+        continue;
+      }
+      next = next.map((t) =>
+        t.date === item.date
+          ? {
+              ...t,
+              events: t.events.map((event) =>
+                event.slot === slot
+                  ? { ...event, schedule: item.schedule }
+                  : event,
+              ),
+            }
+          : t,
+      );
+    }
+    setTrainings(sortByDate(next));
+    setImportOpen(false);
+  }
+
   return (
     <>
       <PageTitle title="Inschrijven trainingen" />
@@ -312,9 +371,10 @@ export default function InschrijvenTraining() {
 
       {importOpen && (
         <ImportModal
-          existingDates={trainings.map((t) => t.date)}
+          trainings={trainings}
           onClose={() => setImportOpen(false)}
           onImport={handleImport}
+          onImportGroup={handleImportGroup}
         />
       )}
 

--- a/src/pages/leden/inschrijven-training/inschrijven-training.tsx
+++ b/src/pages/leden/inschrijven-training/inschrijven-training.tsx
@@ -40,6 +40,9 @@ export default function InschrijvenTraining() {
   const devMode = import.meta.env.DEV;
 
   const [devView, setDevView] = useState("Lid");
+  // DEV-only design exploration for the event panels (see the "design
+  // exploration" section in TrainingCard.scss).
+  const [designVariant, setDesignVariant] = useState("Huidig");
   const [trainings, setTrainings] = useState(() =>
     sortByDate(makeMockTrainings()),
   );
@@ -294,7 +297,11 @@ export default function InschrijvenTraining() {
   return (
     <>
       <PageTitle title="Inschrijven trainingen" />
-      <div className="training-page">
+      <div
+        className={`training-page ${
+          designVariant === "Huidig" ? "" : `design-${designVariant.toLowerCase()}`
+        }`}
+      >
         <div className="training-toolbar">
           <div className="training-legend">
             <span className="legend-chip legend-ma">Maandag</span>
@@ -378,6 +385,20 @@ export default function InschrijvenTraining() {
         />
       )}
 
+      {devMode && (
+        <div className="training-dev-switcher training-design-switcher">
+          <span>Design:</span>
+          {["Huidig", "A", "B", "C"].map((variant) => (
+            <button
+              key={variant}
+              className={designVariant === variant ? "is-active" : ""}
+              onClick={() => setDesignVariant(variant)}
+            >
+              {variant}
+            </button>
+          ))}
+        </div>
+      )}
       {devMode && (
         <div className="training-dev-switcher">
           <span>Bekijk als:</span>

--- a/src/pages/leden/inschrijven-training/mock-data.ts
+++ b/src/pages/leden/inschrijven-training/mock-data.ts
@@ -31,33 +31,75 @@ function attendees(count: number, offset = 0) {
   });
 }
 
-const SPRINT_SCHEDULE = `Warming-up: 2 rondjes + loopscholing
-Kern: 3× 3×60m vliegend, rust 3' / serierust 6'
-Afsluiting: 4× starts uit blokken + core`;
+// Realistic example schedules (as actually written by trainers), cycled per
+// training so the preview doesn't repeat the exact same schema every day.
+// MiLa genuinely doesn't get a schedule every training — some slots are
+// intentionally left null here to match that.
+const SPRINT_SCHEDULES: string[] = [
+  `Wedstrijd warming up
+Startblok: wedstrijdsimulatie
+0-5 x 30m 95% vliegende start
+SP = 3 min
+Spikes = Ja`,
+  `6-7 x 67m
+p = 6-7 min
+67%
+spikes = ja met 6-7 puntjes`,
+  `Onderhoud schema lang
+Lange sprint: lange vs korte lopers
+Lange sprinters: 200 - 250 - 300 (- 200)
+Korte sprinters: 120 - 150 - 180 (- 120)
+80-90% SP = 7 min
+Spikes: nee (tenzij wedstrijden)`,
+  `onderhoud schema kort
+70-80-90-100-90-80-70
+P = 3 min
+Spikes: nee (tenzij wedstrijden)`,
+];
 
-const MILA_SCHEDULE = `Warming-up: 15' inlopen + versnellingen
-Kern: 6× 800m @ 10k-tempo, rust 90"
-Afsluiting: 10' uitlopen`;
+const MILA_SCHEDULES: (string | null)[] = [
+  `Competitie voorbereiding 800, 1500, 3000, 5000`,
+  `VO2-max training: 6-7x700 op 5000m tempo; P=600 joggen`,
+  null,
+  null,
+];
 
-const LOOPGROEP_SCHEDULE = `Warming-up: 10' rustig inlopen
-Kern: 40' duurloop D1/D2 in groepen
-Afsluiting: rekken en core`;
+const LOOPGROEP_SCHEDULES: string[] = [
+  `Long run (50-70') D0`,
+  `2 x (6'-7') LT1
+HP=4' D1`,
+  `10x600m LT2
+HP=200m D1`,
+  `Long run (50-70') D1`,
+];
 
-function baseEvents(id: string, t1: string, t2: string | null): TrainingEvent[] {
+function baseEvents(
+  id: string,
+  index: number,
+  t1: string,
+  t2: string | null,
+): TrainingEvent[] {
+  const sprintSchedule =
+    SPRINT_SCHEDULES[index % SPRINT_SCHEDULES.length] ?? null;
+  const milaSchedule = MILA_SCHEDULES[index % MILA_SCHEDULES.length] ?? null;
+  const loopgroepSchedule =
+    LOOPGROEP_SCHEDULES[index % LOOPGROEP_SCHEDULES.length] ?? null;
   return [
     {
       event_id: `${id}_sprint`,
       slot: "sprint",
       name: "Sprint",
-      schedule: SPRINT_SCHEDULE,
-      comment: "Neem je spikes mee!",
+      schedule: sprintSchedule,
+      comment: sprintSchedule?.includes("Spikes = Ja")
+        ? "Neem je spikes mee!"
+        : null,
       attendees: attendees(3),
     },
     {
       event_id: `${id}_mila`,
       slot: "mila",
       name: "MiLa",
-      schedule: MILA_SCHEDULE,
+      schedule: milaSchedule,
       comment: null,
       attendees: attendees(3, 3),
     },
@@ -65,7 +107,7 @@ function baseEvents(id: string, t1: string, t2: string | null): TrainingEvent[] 
       event_id: `${id}_loopgroep`,
       slot: "loopgroep",
       name: "Loopgroep",
-      schedule: LOOPGROEP_SCHEDULE,
+      schedule: loopgroepSchedule,
       comment: null,
       attendees: attendees(2, 6),
     },
@@ -107,8 +149,10 @@ function upcomingTrainingDates(): string[] {
   return dates;
 }
 
-const T1_EVENTS = ["Kogel", "Ver", "Speer", "Hoog"];
-const T2_EVENTS = ["Discus", "Hinkstap", null, "Polsstok"];
+// Technisch 1 / Technisch 2, paired per training the way trainers actually
+// fill them in.
+const T1_EVENTS = ["Hoog", "Horde", "Hoog", "Ver"];
+const T2_EVENTS = ["Kogel", "Discus", "Kogel", "Speer"];
 
 export function makeMockTrainings(): TrainingDay[] {
   return upcomingTrainingDates().map((date, i) => {
@@ -122,6 +166,7 @@ export function makeMockTrainings(): TrainingDay[] {
       warmup_trainers: "Jasmijn",
       events: baseEvents(
         id,
+        i,
         T1_EVENTS[i % T1_EVENTS.length] ?? "Kogel",
         T2_EVENTS[i % T2_EVENTS.length] ?? null,
       ),

--- a/src/pages/leden/inschrijven-training/mock-data.ts
+++ b/src/pages/leden/inschrijven-training/mock-data.ts
@@ -1,0 +1,154 @@
+// Mock data until the backend endpoints from docs/training-backend-spec.md
+// exist. Dates are generated relative to today so the page always shows
+// upcoming trainings.
+
+import type { CompetitionStanding, TrainingDay, TrainingEvent } from "./types";
+import { defaultTimes } from "./utils";
+
+export const MOCK_USER = {
+  user_id: "0_arnold_debugvarken",
+  name: "Arnold het Aardvarken",
+};
+
+const NAMES = [
+  "Koers Klaproos",
+  "Steeple van Horden",
+  "Milo Meters",
+  "Vera Verspringen",
+  "Daan Discus",
+  "Sanne Sprint",
+  "Pim Polsstok",
+  "Lotte Loopgroep",
+  "Casper Kogel",
+  "Hanna Hink",
+];
+
+function attendees(count: number, offset = 0) {
+  return Array.from({ length: count }, (_, i) => {
+    const name = NAMES[(i + offset) % NAMES.length] ?? "Onbekend Lid";
+    const first = name.split(" ")[0] ?? name;
+    return { user_id: `0_mock_${first.toLowerCase()}`, name };
+  });
+}
+
+const SPRINT_SCHEDULE = `Warming-up: 2 rondjes + loopscholing
+Kern: 3× 3×60m vliegend, rust 3' / serierust 6'
+Afsluiting: 4× starts uit blokken + core`;
+
+const MILA_SCHEDULE = `Warming-up: 15' inlopen + versnellingen
+Kern: 6× 800m @ 10k-tempo, rust 90"
+Afsluiting: 10' uitlopen`;
+
+const LOOPGROEP_SCHEDULE = `Warming-up: 10' rustig inlopen
+Kern: 40' duurloop D1/D2 in groepen
+Afsluiting: rekken en core`;
+
+function baseEvents(id: string, t1: string, t2: string | null): TrainingEvent[] {
+  return [
+    {
+      event_id: `${id}_sprint`,
+      slot: "sprint",
+      name: "Sprint",
+      schedule: SPRINT_SCHEDULE,
+      comment: "Neem je spikes mee!",
+      attendees: attendees(3),
+    },
+    {
+      event_id: `${id}_mila`,
+      slot: "mila",
+      name: "MiLa",
+      schedule: MILA_SCHEDULE,
+      comment: null,
+      attendees: attendees(3, 3),
+    },
+    {
+      event_id: `${id}_loopgroep`,
+      slot: "loopgroep",
+      name: "Loopgroep",
+      schedule: LOOPGROEP_SCHEDULE,
+      comment: null,
+      attendees: attendees(2, 6),
+    },
+    {
+      event_id: `${id}_t1`,
+      slot: "t1",
+      name: t1,
+      schedule: null,
+      comment: null,
+      attendees: attendees(2, 8),
+    },
+    {
+      event_id: `${id}_t2`,
+      slot: "t2",
+      name: t2,
+      schedule: null,
+      comment: null,
+      attendees: [],
+    },
+  ];
+}
+
+function isoDaysFromNow(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+// The next three weeks of Mon (1), Wed (3) and Sat (6) trainings.
+function upcomingTrainingDates(): string[] {
+  const dates: string[] = [];
+  for (let offset = 0; offset < 21 && dates.length < 8; offset++) {
+    const iso = isoDaysFromNow(offset);
+    const weekday = new Date(`${iso}T12:00:00`).getDay();
+    if (weekday === 1 || weekday === 3 || weekday === 6) {
+      dates.push(iso);
+    }
+  }
+  return dates;
+}
+
+const T1_EVENTS = ["Kogel", "Ver", "Speer", "Hoog"];
+const T2_EVENTS = ["Discus", "Hinkstap", null, "Polsstok"];
+
+export function makeMockTrainings(): TrainingDay[] {
+  return upcomingTrainingDates().map((date, i) => {
+    const id = `training_${date}`;
+    const training: TrainingDay = {
+      training_id: id,
+      date,
+      ...defaultTimes(date),
+      cancelled: null,
+      trainers: "Jasmijn, Karel, Roos, Sven, Nina",
+      warmup_trainers: "Jasmijn",
+      events: baseEvents(
+        id,
+        T1_EVENTS[i % T1_EVENTS.length] ?? "Kogel",
+        T2_EVENTS[i % T2_EVENTS.length] ?? null,
+      ),
+    };
+    // One cancelled training to show that state
+    if (i === 3) {
+      training.cancelled = { reason: "NSK Teams" };
+      training.events = training.events.map((event) => ({
+        ...event,
+        attendees: [],
+      }));
+    }
+    // Sign the mock user up for the second training so the
+    // "ingeschreven" state is visible.
+    const firstEvent = training.events[0];
+    if (i === 1 && firstEvent) {
+      firstEvent.attendees = [...firstEvent.attendees, { ...MOCK_USER }];
+    }
+    return training;
+  });
+}
+
+export function makeMockStandings(): CompetitionStanding[] {
+  const points = [24, 21, 19, 17, 16, 12, 11, 9, 6, 4];
+  return NAMES.map((name, i) => ({
+    user_id: `0_mock_${(name.split(" ")[0] ?? name).toLowerCase()}`,
+    name,
+    points: points[i] ?? 0,
+  })).concat([{ user_id: MOCK_USER.user_id, name: MOCK_USER.name, points: 14 }]);
+}

--- a/src/pages/leden/inschrijven-training/types.ts
+++ b/src/pages/leden/inschrijven-training/types.ts
@@ -1,0 +1,63 @@
+// Types for the training sign-up feature. These mirror the backend
+// specification in docs/training-backend-spec.md — keep them in sync so
+// swapping the mock data for real API calls is a drop-in change.
+
+export interface Attendee {
+  user_id: string;
+  name: string;
+}
+
+// Every training day has the same five groups: the three fixed running
+// groups (which always come with a workout schedule) and two technical
+// slots (T1/T2) whose event differs per training and never has a schedule.
+export type GroupSlot = "sprint" | "mila" | "loopgroep" | "t1" | "t2";
+
+export interface TrainingEvent {
+  event_id: string;
+  slot: GroupSlot;
+  // "Sprint" / "MiLa" / "Loopgroep" for the fixed groups; the event name
+  // (e.g. "Kogel") for t1/t2. Null for an unused technical slot.
+  name: string | null;
+  // Workout schedule, only for sprint/mila/loopgroep.
+  schedule: string | null;
+  // Short trainer note shown to everyone, e.g. "Neem spikes mee".
+  comment: string | null;
+  attendees: Attendee[];
+}
+
+export interface TrainingDay {
+  training_id: string;
+  // ISO date, e.g. "2026-07-06"
+  date: string;
+  start_time: string;
+  end_time: string | null;
+  cancelled: { reason: string } | null;
+  // The five trainers of this training, comma-separated. The first name is
+  // the contact point ("aanspreekpunt") for the day.
+  trainers: string | null;
+  // Who leads the joint warming-up.
+  warmup_trainers: string | null;
+  events: TrainingEvent[];
+}
+
+export interface CompetitionStanding {
+  user_id: string;
+  name: string;
+  points: number;
+}
+
+// A training day parsed from an import file, before it gets an id.
+// Columns: date, sprint/mila/loopgroep schedule, t1/t2 event,
+// available trainers, warm-up trainers.
+// "available trainers" holds the five trainer names in group order
+// (Sprint, MiLa, Loopgroep, T1, T2), separated by commas.
+export interface ImportedTraining {
+  date: string;
+  sprint_schedule: string | null;
+  mila_schedule: string | null;
+  loopgroep_schedule: string | null;
+  t1_event: string | null;
+  t2_event: string | null;
+  available_trainers: string | null;
+  warmup_trainers: string | null;
+}

--- a/src/pages/leden/inschrijven-training/types.ts
+++ b/src/pages/leden/inschrijven-training/types.ts
@@ -46,11 +46,13 @@ export interface CompetitionStanding {
   points: number;
 }
 
-// A training day parsed from an import file, before it gets an id.
-// Columns: date, sprint/mila/loopgroep schedule, t1/t2 event,
-// available trainers, warm-up trainers.
-// "available trainers" holds the five trainer names in group order
-// (Sprint, MiLa, Loopgroep, T1, T2), separated by commas.
+// The three groups that carry a workout schedule (T1/T2 never do).
+export type ScheduleSlot = "sprint" | "mila" | "loopgroep";
+
+// A training day parsed from a full-schedule import file, before it gets an
+// id. Columns: date, sprint/mila/loopgroep schedule, t1/t2 event, available
+// trainers, warm-up trainers. Only the date is required; all other columns
+// may be missing or empty.
 export interface ImportedTraining {
   date: string;
   sprint_schedule: string | null;
@@ -60,4 +62,11 @@ export interface ImportedTraining {
   t2_event: string | null;
   available_trainers: string | null;
   warmup_trainers: string | null;
+}
+
+// One row of a per-group import: a trainer uploads all schedules for their
+// own group (e.g. all Sprint trainings) in one go.
+export interface ImportedGroupSchedule {
+  date: string;
+  schedule: string | null;
 }

--- a/src/pages/leden/inschrijven-training/utils.ts
+++ b/src/pages/leden/inschrijven-training/utils.ts
@@ -1,4 +1,9 @@
-import type { GroupSlot, ImportedTraining, TrainingDay } from "./types";
+import type {
+  GroupSlot,
+  ImportedGroupSchedule,
+  ImportedTraining,
+  TrainingDay,
+} from "./types";
 
 const WEEKDAYS_LONG = [
   "Zondag",
@@ -134,13 +139,10 @@ function parseCsvImport(content: string): ImportedTraining[] {
   // Skip an optional header row
   const startIndex = rows[0]?.[0]?.trim().toLowerCase() === "date" ? 1 : 0;
 
+  // Only the date column is required; the file may have any number of the
+  // remaining columns (missing or empty cells simply mean "not set").
   return rows.slice(startIndex).map((row, i) => {
     const line = startIndex + i + 1;
-    if (row.length < 8) {
-      throw new Error(
-        `Regel ${line}: verwacht 8 kolommen (date, sprint schedule, mila schedule, loopgroep schedule, t1 event, t2 event, available trainers, warm-up trainers).`,
-      );
-    }
     const cell = (index: number): string | null => {
       const value = (row[index] ?? "").trim();
       return value === "" ? null : value;
@@ -161,6 +163,58 @@ function parseCsvImport(content: string): ImportedTraining[] {
       available_trainers: cell(6),
       warmup_trainers: cell(7),
     };
+  });
+}
+
+// --- Per-group schedule import -----------------------------------------------
+// A trainer delivers all schedules for their own group (e.g. every Sprint
+// training of the coming period) as two columns: date, schedule.
+
+export function parseGroupScheduleFile(
+  filename: string,
+  content: string,
+): ImportedGroupSchedule[] {
+  if (filename.toLowerCase().endsWith(".json")) {
+    const data: unknown = JSON.parse(content);
+    if (!Array.isArray(data)) {
+      throw new Error("JSON-bestand moet een lijst van schema's zijn.");
+    }
+    return data.map((raw, i) => {
+      const item = raw as Record<string, unknown>;
+      const date = item["date"];
+      const schedule = item["schedule"];
+      if (typeof date !== "string" || !isIsoDate(date)) {
+        throw new Error(
+          `Schema ${i + 1}: ongeldige datum (verwacht JJJJ-MM-DD).`,
+        );
+      }
+      return {
+        date,
+        schedule:
+          typeof schedule === "string" && schedule.trim() !== ""
+            ? schedule
+            : null,
+      };
+    });
+  }
+
+  const rows = parseCsvRows(content).filter((row) =>
+    row.some((cell) => cell.trim() !== ""),
+  );
+  if (rows.length === 0) {
+    throw new Error("Het bestand is leeg.");
+  }
+  const startIndex = rows[0]?.[0]?.trim().toLowerCase() === "date" ? 1 : 0;
+
+  return rows.slice(startIndex).map((row, i) => {
+    const date = (row[0] ?? "").trim();
+    if (!isIsoDate(date)) {
+      throw new Error(
+        `Regel ${startIndex + i + 1}: ongeldige datum "${date}" (verwacht JJJJ-MM-DD).`,
+      );
+    }
+    const schedule = (row[1] ?? "").trim();
+    return { date, schedule: schedule === "" ? null : schedule };
   });
 }
 

--- a/src/pages/leden/inschrijven-training/utils.ts
+++ b/src/pages/leden/inschrijven-training/utils.ts
@@ -1,0 +1,269 @@
+import type { GroupSlot, ImportedTraining, TrainingDay } from "./types";
+
+const WEEKDAYS_LONG = [
+  "Zondag",
+  "Maandag",
+  "Dinsdag",
+  "Woensdag",
+  "Donderdag",
+  "Vrijdag",
+  "Zaterdag",
+];
+
+const MONTHS_SHORT = [
+  "jan",
+  "feb",
+  "mrt",
+  "apr",
+  "mei",
+  "jun",
+  "jul",
+  "aug",
+  "sep",
+  "okt",
+  "nov",
+  "dec",
+];
+
+export function weekdayOf(isoDate: string): number {
+  return new Date(`${isoDate}T12:00:00`).getDay();
+}
+
+export function formatWeekday(isoDate: string): string {
+  return WEEKDAYS_LONG[weekdayOf(isoDate)] ?? "";
+}
+
+export function formatDayMonth(isoDate: string): string {
+  const d = new Date(`${isoDate}T12:00:00`);
+  return `${d.getDate()} ${MONTHS_SHORT[d.getMonth()]}`;
+}
+
+// Maps a date to the css modifier that colors the card: monday, wednesday and
+// saturday each have a fixed color so the days are easy to tell apart.
+export function dayColorClass(isoDate: string): string {
+  switch (weekdayOf(isoDate)) {
+    case 1:
+      return "day-ma";
+    case 3:
+      return "day-wo";
+    case 6:
+      return "day-za";
+    default:
+      return "day-other";
+  }
+}
+
+// Default training times: Ma/Wo evening, Za morning.
+export function defaultTimes(isoDate: string): {
+  start_time: string;
+  end_time: string;
+} {
+  return weekdayOf(isoDate) === 6
+    ? { start_time: "10:15", end_time: "11:45" }
+    : { start_time: "18:15", end_time: "19:45" };
+}
+
+// --- Schedule import parsing -------------------------------------------------
+// Two formats are supported, matching the backend spec. Both carry the same
+// eight fields per training day:
+//   date, sprint schedule, mila schedule, loopgroep schedule,
+//   t1 event, t2 event, available trainers, warm-up trainers
+// CSV cells may be quoted and contain newlines (multiline schedules from
+// Excel/Sheets exports).
+
+export function parseImportFile(
+  filename: string,
+  content: string,
+): ImportedTraining[] {
+  if (filename.toLowerCase().endsWith(".json")) {
+    return parseJsonImport(content);
+  }
+  return parseCsvImport(content);
+}
+
+const JSON_FIELDS = [
+  "sprint_schedule",
+  "mila_schedule",
+  "loopgroep_schedule",
+  "t1_event",
+  "t2_event",
+  "available_trainers",
+  "warmup_trainers",
+] as const;
+
+function parseJsonImport(content: string): ImportedTraining[] {
+  const data: unknown = JSON.parse(content);
+  if (!Array.isArray(data)) {
+    throw new Error("JSON-bestand moet een lijst van trainingen zijn.");
+  }
+  return data.map((raw, i) => {
+    const item = raw as Record<string, unknown>;
+    const date = item["date"];
+    if (typeof date !== "string" || !isIsoDate(date)) {
+      throw new Error(
+        `Training ${i + 1}: ongeldige datum (verwacht JJJJ-MM-DD).`,
+      );
+    }
+    const imported: ImportedTraining = {
+      date,
+      sprint_schedule: null,
+      mila_schedule: null,
+      loopgroep_schedule: null,
+      t1_event: null,
+      t2_event: null,
+      available_trainers: null,
+      warmup_trainers: null,
+    };
+    for (const field of JSON_FIELDS) {
+      const value = item[field];
+      if (typeof value === "string" && value.trim() !== "") {
+        imported[field] = value;
+      }
+    }
+    return imported;
+  });
+}
+
+function parseCsvImport(content: string): ImportedTraining[] {
+  const rows = parseCsvRows(content).filter((row) =>
+    row.some((cell) => cell.trim() !== ""),
+  );
+  if (rows.length === 0) {
+    throw new Error("Het bestand is leeg.");
+  }
+  // Skip an optional header row
+  const startIndex = rows[0]?.[0]?.trim().toLowerCase() === "date" ? 1 : 0;
+
+  return rows.slice(startIndex).map((row, i) => {
+    const line = startIndex + i + 1;
+    if (row.length < 8) {
+      throw new Error(
+        `Regel ${line}: verwacht 8 kolommen (date, sprint schedule, mila schedule, loopgroep schedule, t1 event, t2 event, available trainers, warm-up trainers).`,
+      );
+    }
+    const cell = (index: number): string | null => {
+      const value = (row[index] ?? "").trim();
+      return value === "" ? null : value;
+    };
+    const date = (row[0] ?? "").trim();
+    if (!isIsoDate(date)) {
+      throw new Error(
+        `Regel ${line}: ongeldige datum "${date}" (verwacht JJJJ-MM-DD).`,
+      );
+    }
+    return {
+      date,
+      sprint_schedule: cell(1),
+      mila_schedule: cell(2),
+      loopgroep_schedule: cell(3),
+      t1_event: cell(4),
+      t2_event: cell(5),
+      available_trainers: cell(6),
+      warmup_trainers: cell(7),
+    };
+  });
+}
+
+// CSV parser with support for quoted cells containing commas, escaped
+// quotes ("") and newlines, as produced by Excel/Google Sheets exports.
+function parseCsvRows(content: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < content.length; i++) {
+    const char = content[i];
+    if (inQuotes) {
+      if (char === '"') {
+        if (content[i + 1] === '"') {
+          cell += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        cell += char;
+      }
+    } else if (char === '"') {
+      inQuotes = true;
+    } else if (char === ",") {
+      row.push(cell);
+      cell = "";
+    } else if (char === "\n" || char === "\r") {
+      if (char === "\r" && content[i + 1] === "\n") i++;
+      row.push(cell);
+      cell = "";
+      rows.push(row);
+      row = [];
+    } else {
+      cell += char;
+    }
+  }
+  if (cell !== "" || row.length > 0) {
+    row.push(cell);
+    rows.push(row);
+  }
+  return rows;
+}
+
+function isIsoDate(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+// The five groups of every training day, in display and import order.
+export const SLOT_ORDER: GroupSlot[] = [
+  "sprint",
+  "mila",
+  "loopgroep",
+  "t1",
+  "t2",
+];
+
+export const FIXED_SLOT_NAMES: Partial<Record<GroupSlot, string>> = {
+  sprint: "Sprint",
+  mila: "MiLa",
+  loopgroep: "Loopgroep",
+};
+
+// Splits a comma-separated name list into clean names.
+export function splitNames(names: string | null): string[] {
+  return (names ?? "")
+    .split(",")
+    .map((name) => name.trim())
+    .filter((name) => name !== "");
+}
+
+export function toTrainingDay(
+  imported: ImportedTraining,
+  id: string,
+): TrainingDay {
+  const slotName = (slot: GroupSlot): string | null => {
+    if (slot === "t1") return imported.t1_event;
+    if (slot === "t2") return imported.t2_event;
+    return FIXED_SLOT_NAMES[slot] ?? null;
+  };
+  const slotSchedule = (slot: GroupSlot): string | null => {
+    if (slot === "sprint") return imported.sprint_schedule;
+    if (slot === "mila") return imported.mila_schedule;
+    if (slot === "loopgroep") return imported.loopgroep_schedule;
+    return null;
+  };
+
+  return {
+    training_id: id,
+    date: imported.date,
+    ...defaultTimes(imported.date),
+    cancelled: null,
+    trainers: imported.available_trainers,
+    warmup_trainers: imported.warmup_trainers,
+    events: SLOT_ORDER.map((slot) => ({
+      event_id: `${id}_${slot}`,
+      slot,
+      name: slotName(slot),
+      schedule: slotSchedule(slot),
+      comment: null,
+      attendees: [],
+    })),
+  };
+}

--- a/src/pages/leden/leden/leden.tsx
+++ b/src/pages/leden/leden/leden.tsx
@@ -62,7 +62,7 @@ export default function Leden() {
       <PageTitle title={`Welkom, ${session.user.firstname}`} />
       <div className="leden-container">
         <div className="leden-routes">
-          <Link className="leden-link leden-link-double" to="">
+          <Link className="leden-link leden-link-double" to="inschrijven_training">
             <h1 className="leden-link-header leden-link-header-double">
               Inschrijven trainingen
             </h1>

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -54,6 +54,10 @@ export default [
         "./pages/leden/verjaardagen/verjaardagen.tsx",
       ),
       route("hordes", "./pages/leden/hordes/Hordes.tsx"),
+      route(
+        "inschrijven_training",
+        "./pages/leden/inschrijven-training/inschrijven-training.tsx",
+      ),
     ]),
     ...prefix("account", [
       route("register", "./pages/account/register/register.tsx"),

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -4,6 +4,7 @@ $dodeka_blauw90p: #193459;
 $dodeka_rood: #cb4b3d;
 $baan_rood: #BB4B3D;
 $dodeka_grijs: #93a3b1;
+$tu_blauw: #00a6d6;
 
 // Font weights
 $bold: 700;


### PR DESCRIPTION
## Summary
- Rebuilds the "inschrijven trainingen" page (previously a dead link / stale prototype) on mock data shaped like the intended backend
- Five fixed groups per training day (Sprint/MiLa/Loopgroep with workout schedules, T1/T2 technical slots without), day-of-week color coding, and a member's own signup shown on the card and per group
- Per-day trainer roster: contact point highlighted in TU blauw, warming-up trainer(s) in baan-rood
- Trainer tools: cancel/restore a day with a reason, edit group names/schedules/comments, remove no-shows, add days, and bulk-import a schedule (CSV/JSON) with per-date conflict resolution
- Board-only trainingscompetitie standings panel, points derived from signups
- Adds `docs/training-backend-spec.md` — a spec for implementing the real backend endpoints this page is designed against

## Test plan
- [x] `npm run check` passes for all new/changed files
- [x] Manually verified in browser preview: member signup/switch-event flow, trainer manage mode (cancel, edit schedule/comment, rename T1/T2, remove attendee), schedule import with conflict resolution, board competition panel, mobile layout
- [ ] Manual review of the backend spec before implementation begins