### PR TITLE
Add leden-only Foto's page for browsing event photo albums

### DIFF
--- a/src/functions/debug-user.ts
+++ b/src/functions/debug-user.ts
@@ -64,3 +64,57 @@ export function getDebugBirthdays(): Birthday[] | null {
   if (!isDebugUserActive()) return null;
   return DEBUG_BIRTHDAYS;
 }
+
+function placeholderImage(color: string, label: string): string {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600"><rect width="800" height="600" fill="${color}"/><text x="400" y="315" font-family="sans-serif" font-size="48" fill="white" text-anchor="middle">${label}</text></svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+const DEBUG_PRIVATE: Record<string, unknown> = {
+  fotos_events: [
+    {
+      id: "debug-nsk-baan",
+      name: "NSK Baan",
+      date: "2026-06-14",
+      type: "Wedstrijd",
+      image: placeholderImage("#cb4b3d", "NSK Baan"),
+      links: [
+        { label: "dump", url: "https://example.com/dump" },
+        { label: "dodeka", url: "https://example.com/dodeka" },
+      ],
+    },
+    {
+      id: "debug-trainingsweekend",
+      name: "Trainingsweekend Ardennen",
+      date: "2026-04-20",
+      type: "Reis",
+      image: placeholderImage("#001f48", "Ardennen"),
+      links: [
+        { label: "alles", url: "https://example.com/alles" },
+        { label: "focus", url: "https://example.com/focus" },
+        { label: "drone", url: "https://example.com/drone" },
+      ],
+    },
+    {
+      id: "debug-borrel",
+      name: "Eindejaarsborrel",
+      date: "2025-12-19",
+      type: "Gezelligheid",
+      image: placeholderImage("#93a3b1", "Borrel"),
+      links: [{ label: "dump", url: "https://example.com/dump" }],
+    },
+    {
+      id: "debug-baantraining",
+      name: "Baantraining zomer",
+      date: "2025-07-08",
+      type: "Training",
+      image: placeholderImage("#2a9d8f", "Training"),
+      links: [],
+    },
+  ],
+};
+
+export function getDebugPrivate(key: string): unknown | null {
+  if (!isDebugUserActive()) return null;
+  return DEBUG_PRIVATE[key] ?? null;
+}

--- a/src/functions/query.ts
+++ b/src/functions/query.ts
@@ -83,7 +83,14 @@ export function useMemberBirthdays(enabled: boolean) {
 export function usePrivate<T = unknown>(key: string, enabled: boolean) {
   return useQuery({
     queryKey: ["private", key] as const,
-    queryFn: () => backend.getPrivate<T>(key),
+    queryFn: async () => {
+      if (import.meta.env.DEV) {
+        const { getDebugPrivate } = await import("./debug-user.ts");
+        const debug = getDebugPrivate(key);
+        if (debug !== null) return debug as T;
+      }
+      return backend.getPrivate<T>(key);
+    },
     enabled: enabled && !!key,
     retry: false,
   });

--- a/src/pages/leden/fotos/fotos.scss
+++ b/src/pages/leden/fotos/fotos.scss
@@ -1,0 +1,425 @@
+@use "../../../variables";
+
+.fotos-status {
+  color: variables.$dodeka_blauw;
+  margin-left: variables.$margin_x;
+
+  @include variables.respond(mobile) {
+    margin-left: variables.$margin_mobile;
+  }
+}
+
+.fotos-container {
+  margin: 0 variables.$margin_x 4rem;
+
+  @include variables.respond(mobile) {
+    margin: 0 variables.$margin_mobile 3rem;
+  }
+}
+
+// --- Top bar ---
+
+.fotos-topbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 2rem;
+}
+
+.fotos-search {
+  flex: 1 1 14rem;
+  max-width: 20rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid variables.$dodeka_grijs;
+  border-radius: 4px;
+  font-size: variables.$font_small;
+  color: variables.$dodeka_blauw;
+
+  &:focus {
+    outline: 2px solid variables.$dodeka_blauw;
+    outline-offset: -1px;
+  }
+}
+
+.fotos-select {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid variables.$dodeka_grijs;
+  border-radius: 4px;
+  font-size: variables.$font_small;
+  color: variables.$dodeka_blauw;
+  background-color: white;
+}
+
+.fotos-typefilter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+// Dev-only "Bekijk als" toggle, styled distinctly (dashed border) so it
+// reads as a debug affordance rather than a real filter.
+.fotos-viewtoggle {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  border: 1px dashed variables.$dodeka_grijs;
+  border-radius: 999px;
+}
+
+.fotos-chip {
+  padding: 0.4rem 0.9rem;
+  border: 1px solid variables.$dodeka_blauw;
+  border-radius: 999px;
+  background-color: white;
+  color: variables.$dodeka_blauw;
+  font-size: variables.$font_small;
+  cursor: pointer;
+
+  &:hover {
+    background-color: rgba(variables.$dodeka_blauw, 0.08);
+  }
+
+  &--active {
+    background-color: variables.$dodeka_blauw;
+    color: white;
+
+    &:hover {
+      background-color: variables.$dodeka_blauw90p;
+    }
+  }
+}
+
+.fotos-button {
+  padding: 0.5rem 1.25rem;
+  background-color: variables.$dodeka_rood;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: variables.$font_small;
+  font-weight: variables.$bold;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.9;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+
+  &--danger {
+    background-color: white;
+    color: variables.$dodeka_rood;
+    border: 1px solid variables.$dodeka_rood;
+  }
+}
+
+.fotos-add {
+  margin-left: auto;
+}
+
+// --- Grid ---
+
+.fotos-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
+  gap: 1.5rem;
+}
+
+.fotos-card {
+  // Native buttons vertically-center their content internally regardless of
+  // `display`, unless overridden with an explicit flex layout. Without this,
+  // grid row-stretching (to match the tallest card) shifts shorter cards'
+  // image/text down instead of leaving the extra space at the bottom.
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  padding: 0;
+  border: none;
+  border-radius: 8px;
+  background-color: white;
+  box-shadow: 0 1px 4px rgba(variables.$dodeka_blauw, 0.2);
+  overflow: hidden;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 10px rgba(variables.$dodeka_blauw, 0.25);
+  }
+}
+
+.fotos-card-imagewrap {
+  position: relative;
+  aspect-ratio: 4 / 3;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+}
+
+.fotos-badge {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  color: white;
+  font-size: 0.8rem;
+  font-weight: variables.$bold;
+
+  &--wedstrijd {
+    background-color: variables.$dodeka_rood;
+  }
+
+  &--gezelligheid {
+    background-color: #2a9d8f;
+  }
+
+  &--training {
+    background-color: variables.$dodeka_blauw;
+  }
+
+  &--reis {
+    background-color: #0066cc;
+  }
+
+  &--overig {
+    background-color: variables.$dodeka_grijs;
+  }
+}
+
+.fotos-card-edit {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 50%;
+  background-color: rgba(white, 0.9);
+  color: variables.$dodeka_blauw;
+  cursor: pointer;
+
+  &:hover {
+    background-color: white;
+  }
+}
+
+.fotos-card-info {
+  padding: 0.75rem 1rem 1rem;
+}
+
+.fotos-card-name {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  margin: 0;
+  min-height: calc(1.4rem * 2);
+  color: variables.$dodeka_blauw;
+  font-size: 1.1rem;
+  line-height: 1.4rem;
+}
+
+.fotos-card-date {
+  margin: 0.25rem 0 0;
+  color: variables.$dodeka_grijs;
+  font-size: variables.$font_small;
+}
+
+// --- Modals ---
+
+.fotos-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background-color: rgba(variables.$dodeka_blauw, 0.55);
+}
+
+.fotos-modal {
+  position: relative;
+  width: 100%;
+  max-width: 24rem;
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+  padding: 1.5rem;
+  border-radius: 8px;
+  background-color: white;
+
+  &--form {
+    max-width: 32rem;
+  }
+}
+
+.fotos-modal-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.75rem;
+  border: none;
+  background: none;
+  font-size: 1.75rem;
+  line-height: 1;
+  color: variables.$dodeka_grijs;
+  cursor: pointer;
+
+  &:hover {
+    color: variables.$dodeka_blauw;
+  }
+}
+
+.fotos-modal-title {
+  margin: 0 1.5rem 0.25rem 0;
+  color: variables.$dodeka_blauw;
+  font-size: variables.$font_ml;
+}
+
+.fotos-modal-date {
+  margin: 0 0 1rem;
+  color: variables.$dodeka_grijs;
+}
+
+.fotos-modal-empty {
+  color: variables.$dodeka_blauw;
+}
+
+.fotos-modal-links {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.fotos-modal-link {
+  display: block;
+  padding: 0.6rem 1rem;
+  border-radius: 4px;
+  background-color: variables.$dodeka_blauw;
+  color: white;
+  text-align: center;
+  text-decoration: none;
+  font-weight: variables.$bold;
+  text-transform: capitalize;
+
+  &:hover {
+    background-color: variables.$dodeka_blauw90p;
+  }
+}
+
+// --- Create/edit form ---
+
+.fotos-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.fotos-form-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: variables.$dodeka_blauw;
+  font-weight: variables.$bold;
+
+  input,
+  select {
+    padding: 0.5rem;
+    border: 1px solid variables.$dodeka_grijs;
+    border-radius: 4px;
+    font-size: variables.$font_small;
+    font-weight: variables.$normal;
+    color: variables.$dodeka_blauw;
+  }
+}
+
+.fotos-form-preview {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
+.fotos-form-section {
+  margin: 0.5rem 0 0;
+  color: variables.$dodeka_blauw;
+  font-weight: variables.$bold;
+}
+
+.fotos-form-linkrow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  input {
+    padding: 0.4rem 0.5rem;
+    border: 1px solid variables.$dodeka_grijs;
+    border-radius: 4px;
+    font-size: variables.$font_small;
+    color: variables.$dodeka_blauw;
+  }
+
+  input[type="url"] {
+    flex: 1;
+  }
+}
+
+.fotos-form-linklabel {
+  width: 6rem;
+  flex-shrink: 0;
+  color: variables.$dodeka_blauw;
+  text-transform: capitalize;
+
+  input,
+  &input {
+    width: 100%;
+  }
+}
+
+input.fotos-form-linklabel {
+  text-transform: none;
+}
+
+.fotos-form-linkremove {
+  border: none;
+  background: none;
+  color: variables.$dodeka_rood;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+
+.fotos-form-addlink {
+  align-self: flex-start;
+  border: none;
+  background: none;
+  padding: 0;
+  color: variables.$dodeka_rood;
+  font-weight: variables.$bold;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.fotos-form-error {
+  margin: 0;
+  color: variables.$dodeka_rood;
+}
+
+.fotos-form-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}

--- a/src/pages/leden/fotos/fotos.tsx
+++ b/src/pages/leden/fotos/fotos.tsx
@@ -1,0 +1,570 @@
+import { useMemo, useState, type FormEvent } from "react";
+import PageTitle from "$components/PageTitle.tsx";
+import {
+  useSessionInfo,
+  usePrivate,
+  useAdminSetPrivate,
+} from "$functions/query.ts";
+import { PrivateKeyNotSetError } from "$functions/backend.ts";
+import "./fotos.scss";
+
+const FOTOS_KEY = "fotos_events";
+
+const EVENT_TYPES = [
+  "Wedstrijd",
+  "Gezelligheid",
+  "Training",
+  "Reis",
+  "Overig",
+] as const;
+type EventType = (typeof EVENT_TYPES)[number];
+
+// Standard link names shown in the create form; extra names can be added there
+const DEFAULT_LINK_LABELS = ["dump", "dodeka", "alles", "focus"];
+
+interface PhotoLink {
+  label: string;
+  url: string;
+}
+
+interface PhotoEvent {
+  id: string;
+  name: string;
+  date: string; // YYYY-MM-DD
+  type: EventType;
+  image: string; // data URL, resized on upload
+  links: PhotoLink[];
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("nl-NL", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+// Resize uploaded photos so the KV store stays small
+function readAndResizeImage(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        const maxWidth = 800;
+        const scale = Math.min(1, maxWidth / img.width);
+        const canvas = document.createElement("canvas");
+        canvas.width = Math.round(img.width * scale);
+        canvas.height = Math.round(img.height * scale);
+        const ctx = canvas.getContext("2d");
+        if (!ctx) {
+          reject(new Error("Canvas niet beschikbaar"));
+          return;
+        }
+        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+        resolve(canvas.toDataURL("image/jpeg", 0.8));
+      };
+      img.onerror = () => reject(new Error("Kon afbeelding niet laden"));
+      img.src = reader.result as string;
+    };
+    reader.onerror = () => reject(new Error("Kon bestand niet lezen"));
+    reader.readAsDataURL(file);
+  });
+}
+
+function typeSlug(type: EventType): string {
+  return type.toLowerCase();
+}
+
+function LinksModal({
+  event,
+  onClose,
+}: {
+  event: PhotoEvent;
+  onClose: () => void;
+}) {
+  return (
+    <div className="fotos-overlay" onClick={onClose}>
+      <div className="fotos-modal" onClick={(e) => e.stopPropagation()}>
+        <button className="fotos-modal-close" onClick={onClose} aria-label="Sluiten">
+          ×
+        </button>
+        <h2 className="fotos-modal-title">{event.name}</h2>
+        <p className="fotos-modal-date">{formatDate(event.date)}</p>
+        {event.links.length === 0 ? (
+          <p className="fotos-modal-empty">
+            Er zijn nog geen links voor dit evenement.
+          </p>
+        ) : (
+          <div className="fotos-modal-links">
+            {event.links.map((link) => (
+              <a
+                key={link.label}
+                href={link.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="fotos-modal-link"
+              >
+                {link.label}
+              </a>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface LinkRow {
+  label: string;
+  url: string;
+  custom: boolean;
+}
+
+function eventToLinkRows(event: PhotoEvent | null): LinkRow[] {
+  const rows: LinkRow[] = DEFAULT_LINK_LABELS.map((label) => ({
+    label,
+    url: event?.links.find((l) => l.label === label)?.url ?? "",
+    custom: false,
+  }));
+  for (const link of event?.links ?? []) {
+    if (!DEFAULT_LINK_LABELS.includes(link.label)) {
+      rows.push({ label: link.label, url: link.url, custom: true });
+    }
+  }
+  return rows;
+}
+
+function EditModal({
+  existing,
+  saving,
+  error,
+  onSave,
+  onDelete,
+  onClose,
+}: {
+  existing: PhotoEvent | null;
+  saving: boolean;
+  error: string | null;
+  onSave: (event: PhotoEvent) => void;
+  onDelete: (id: string) => void;
+  onClose: () => void;
+}) {
+  const [name, setName] = useState(existing?.name ?? "");
+  const [date, setDate] = useState(existing?.date ?? "");
+  const [type, setType] = useState<EventType>(existing?.type ?? "Overig");
+  const [image, setImage] = useState<string | null>(existing?.image ?? null);
+  const [linkRows, setLinkRows] = useState<LinkRow[]>(() =>
+    eventToLinkRows(existing),
+  );
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const handleFile = async (file: File | undefined) => {
+    if (!file) return;
+    try {
+      setImage(await readAndResizeImage(file));
+      setFormError(null);
+    } catch (e) {
+      setFormError(e instanceof Error ? e.message : "Upload mislukt");
+    }
+  };
+
+  const updateRow = (index: number, patch: Partial<LinkRow>) => {
+    setLinkRows((rows) =>
+      rows.map((row, i) => (i === index ? { ...row, ...patch } : row)),
+    );
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!image) {
+      setFormError("Upload eerst een foto.");
+      return;
+    }
+    if (!name.trim() || !date) {
+      setFormError("Vul een naam en datum in.");
+      return;
+    }
+    const links = linkRows
+      .filter((row) => row.label.trim() && row.url.trim())
+      .map((row) => ({ label: row.label.trim(), url: row.url.trim() }));
+    onSave({
+      id: existing?.id ?? crypto.randomUUID(),
+      name: name.trim(),
+      date,
+      type,
+      image,
+      links,
+    });
+  };
+
+  return (
+    <div className="fotos-overlay" onClick={onClose}>
+      <div
+        className="fotos-modal fotos-modal--form"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button className="fotos-modal-close" onClick={onClose} aria-label="Sluiten">
+          ×
+        </button>
+        <h2 className="fotos-modal-title">
+          {existing ? "Kaart bewerken" : "Nieuwe kaart"}
+        </h2>
+        <form className="fotos-form" onSubmit={handleSubmit}>
+          <label className="fotos-form-label">
+            Foto
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(e) => handleFile(e.target.files?.[0])}
+            />
+          </label>
+          {image && (
+            <img src={image} alt="" className="fotos-form-preview" />
+          )}
+          <label className="fotos-form-label">
+            Naam evenement
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Bijv. NSK Baan"
+            />
+          </label>
+          <label className="fotos-form-label">
+            Datum
+            <input
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+            />
+          </label>
+          <label className="fotos-form-label">
+            Type
+            <select
+              value={type}
+              onChange={(e) => setType(e.target.value as EventType)}
+            >
+              {EVENT_TYPES.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <p className="fotos-form-section">Links (alleen ingevulde links worden getoond)</p>
+          {linkRows.map((row, i) => (
+            <div className="fotos-form-linkrow" key={i}>
+              {row.custom ? (
+                <input
+                  type="text"
+                  className="fotos-form-linklabel"
+                  value={row.label}
+                  placeholder="naam"
+                  onChange={(e) => updateRow(i, { label: e.target.value })}
+                />
+              ) : (
+                <span className="fotos-form-linklabel">{row.label}</span>
+              )}
+              <input
+                type="url"
+                value={row.url}
+                placeholder="https://..."
+                onChange={(e) => updateRow(i, { url: e.target.value })}
+              />
+              {row.custom && (
+                <button
+                  type="button"
+                  className="fotos-form-linkremove"
+                  aria-label="Link verwijderen"
+                  onClick={() =>
+                    setLinkRows((rows) => rows.filter((_, j) => j !== i))
+                  }
+                >
+                  ×
+                </button>
+              )}
+            </div>
+          ))}
+          <button
+            type="button"
+            className="fotos-form-addlink"
+            onClick={() =>
+              setLinkRows((rows) => [
+                ...rows,
+                { label: "", url: "", custom: true },
+              ])
+            }
+          >
+            + Link toevoegen
+          </button>
+
+          {(formError ?? error) && (
+            <p className="fotos-form-error">{formError ?? error}</p>
+          )}
+
+          <div className="fotos-form-actions">
+            <button type="submit" className="fotos-button" disabled={saving}>
+              {saving ? "Opslaan..." : "Klaar"}
+            </button>
+            {existing && (
+              <button
+                type="button"
+                className="fotos-button fotos-button--danger"
+                disabled={saving}
+                onClick={() => onDelete(existing.id)}
+              >
+                Verwijderen
+              </button>
+            )}
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default function Fotos() {
+  const { data: session, isLoading: sessionLoading } = useSessionInfo();
+  const loggedIn = !!session;
+  const isMember = session?.user.permissions.includes("member") ?? false;
+  const isAdmin = session?.user.permissions.includes("admin") ?? false;
+
+  const eventsQuery = usePrivate<PhotoEvent[]>(FOTOS_KEY, loggedIn && isMember);
+  const setPrivate = useAdminSetPrivate();
+
+  // Dev-only toggle to preview the admin/lid view without needing a real
+  // admin session. Has no effect (and isn't rendered) outside of dev.
+  const isDev = import.meta.env.DEV;
+  const [devViewAsAdmin, setDevViewAsAdmin] = useState(false);
+  const showAdminUi = isDev ? devViewAsAdmin : isAdmin;
+
+  const [search, setSearch] = useState("");
+  const [yearFilter, setYearFilter] = useState<string>("alle");
+  const [typeFilter, setTypeFilter] = useState<EventType | "alle">("alle");
+  const [openEvent, setOpenEvent] = useState<PhotoEvent | null>(null);
+  const [editState, setEditState] = useState<
+    { open: false } | { open: true; event: PhotoEvent | null }
+  >({ open: false });
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const events: PhotoEvent[] = useMemo(() => {
+    if (eventsQuery.error instanceof PrivateKeyNotSetError) return [];
+    return eventsQuery.data ?? [];
+  }, [eventsQuery.data, eventsQuery.error]);
+
+  const years = useMemo(() => {
+    const set = new Set(events.map((e) => e.date.slice(0, 4)));
+    return [...set].sort((a, b) => b.localeCompare(a));
+  }, [events]);
+
+  const visibleEvents = useMemo(() => {
+    return events
+      .filter((e) => yearFilter === "alle" || e.date.startsWith(yearFilter))
+      .filter((e) => typeFilter === "alle" || e.type === typeFilter)
+      .filter((e) =>
+        e.name.toLowerCase().includes(search.trim().toLowerCase()),
+      )
+      .sort((a, b) => b.date.localeCompare(a.date));
+  }, [events, yearFilter, typeFilter, search]);
+
+  const saveEvents = async (next: PhotoEvent[]) => {
+    setSaveError(null);
+    try {
+      await setPrivate.mutateAsync({
+        key: FOTOS_KEY,
+        value: next,
+        role: "member",
+      });
+      setEditState({ open: false });
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : "Opslaan mislukt");
+    }
+  };
+
+  if (sessionLoading) {
+    return (
+      <>
+        <PageTitle title="Foto's" />
+        <p className="fotos-status">Laden...</p>
+      </>
+    );
+  }
+
+  if (!loggedIn) {
+    return (
+      <>
+        <PageTitle title="Foto's" />
+        <p className="fotos-status">
+          Deze pagina is helaas niet toegankelijk als je niet ingelogd bent. Log
+          in om deze pagina te kunnen bekijken.
+        </p>
+      </>
+    );
+  }
+
+  if (!isMember) {
+    return (
+      <>
+        <PageTitle title="Foto's" />
+        <p className="fotos-status">
+          Je hebt een actief lidmaatschap nodig om deze pagina te bekijken.
+        </p>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <PageTitle title="Foto's" />
+      <div className="fotos-container">
+        <div className="fotos-topbar">
+          <input
+            type="search"
+            className="fotos-search"
+            placeholder="Zoek een evenement..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <select
+            className="fotos-select"
+            value={yearFilter}
+            onChange={(e) => setYearFilter(e.target.value)}
+          >
+            <option value="alle">Alle jaren</option>
+            {years.map((year) => (
+              <option key={year} value={year}>
+                {year}
+              </option>
+            ))}
+          </select>
+          <div className="fotos-typefilter">
+            <button
+              className={`fotos-chip ${typeFilter === "alle" ? "fotos-chip--active" : ""}`}
+              onClick={() => setTypeFilter("alle")}
+            >
+              Alles
+            </button>
+            {EVENT_TYPES.map((t) => (
+              <button
+                key={t}
+                className={`fotos-chip ${typeFilter === t ? "fotos-chip--active" : ""}`}
+                onClick={() => setTypeFilter(t)}
+              >
+                {t}
+              </button>
+            ))}
+          </div>
+          {isDev && (
+            <div className="fotos-viewtoggle" role="group" aria-label="Bekijk als (alleen dev)">
+              <button
+                type="button"
+                className={`fotos-chip ${devViewAsAdmin ? "fotos-chip--active" : ""}`}
+                onClick={() => setDevViewAsAdmin(true)}
+              >
+                Admin
+              </button>
+              <button
+                type="button"
+                className={`fotos-chip ${!devViewAsAdmin ? "fotos-chip--active" : ""}`}
+                onClick={() => setDevViewAsAdmin(false)}
+              >
+                Lid
+              </button>
+            </div>
+          )}
+          {showAdminUi && (
+            <button
+              className="fotos-button fotos-add"
+              onClick={() => {
+                setSaveError(null);
+                setEditState({ open: true, event: null });
+              }}
+            >
+              + Nieuwe kaart
+            </button>
+          )}
+        </div>
+
+        {eventsQuery.isLoading ? (
+          <p className="fotos-status">Foto's laden...</p>
+        ) : eventsQuery.error &&
+          !(eventsQuery.error instanceof PrivateKeyNotSetError) ? (
+          <p className="fotos-status">Kon de foto's niet laden.</p>
+        ) : visibleEvents.length === 0 ? (
+          <p className="fotos-status">
+            {events.length === 0
+              ? "Er zijn nog geen fotokaarten."
+              : "Geen evenementen gevonden met deze filters."}
+          </p>
+        ) : (
+          <div className="fotos-grid">
+            {visibleEvents.map((event) => (
+              <button
+                key={event.id}
+                className="fotos-card"
+                onClick={() => setOpenEvent(event)}
+              >
+                <div className="fotos-card-imagewrap">
+                  <img src={event.image} alt={event.name} />
+                  <span
+                    className={`fotos-badge fotos-badge--${typeSlug(event.type)}`}
+                  >
+                    {event.type}
+                  </span>
+                  {showAdminUi && (
+                    <span
+                      role="button"
+                      tabIndex={0}
+                      className="fotos-card-edit"
+                      aria-label="Kaart bewerken"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setSaveError(null);
+                        setEditState({ open: true, event });
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          setSaveError(null);
+                          setEditState({ open: true, event });
+                        }
+                      }}
+                    >
+                      ✎
+                    </span>
+                  )}
+                </div>
+                <div className="fotos-card-info">
+                  <h3 className="fotos-card-name">{event.name}</h3>
+                  <p className="fotos-card-date">{formatDate(event.date)}</p>
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {openEvent && (
+        <LinksModal event={openEvent} onClose={() => setOpenEvent(null)} />
+      )}
+      {editState.open && (
+        <EditModal
+          existing={editState.event}
+          saving={setPrivate.isPending}
+          error={saveError}
+          onClose={() => setEditState({ open: false })}
+          onSave={(event) => {
+            const others = events.filter((e) => e.id !== event.id);
+            void saveEvents([...others, event]);
+          }}
+          onDelete={(id) => {
+            void saveEvents(events.filter((e) => e.id !== id));
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/pages/leden/leden/leden.tsx
+++ b/src/pages/leden/leden/leden.tsx
@@ -10,6 +10,7 @@ const memberPages = [
   { title: "Huisstijl", emoji: "🎨", path: "/huisstijl" },
   { title: "Website Updates", emoji: "📰", path: "/update" },
   { title: "Reactietest", emoji: "⚡", path: "/reactietest" },
+  { title: "Foto's", emoji: "📸", path: "/leden/fotos" },
 ];
 
 export default function Leden() {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -54,6 +54,7 @@ export default [
         "./pages/leden/verjaardagen/verjaardagen.tsx",
       ),
       route("hordes", "./pages/leden/hordes/Hordes.tsx"),
+      route("fotos", "./pages/leden/fotos/fotos.tsx"),
     ]),
     ...prefix("account", [
       route("register", "./pages/account/register/register.tsx"),


### PR DESCRIPTION
Adds a photocard grid (name, date, type badge) under /leden/fotos with search, year and type filtering, a links popup per event, and an admin-only create/edit form with photo upload. Includes a dev-only Admin/Lid view toggle to preview both roles locally.