### PR TITLE
OWee frontpage: hero video, sticky OWee banner, summer theme off

### DIFF
--- a/src/content/Changelog.json
+++ b/src/content/Changelog.json
@@ -1,6 +1,15 @@
 {
   "updates": [
     {
+      "id": "bugfix-owee-video-sneller",
+      "datum": "15-08-2026",
+      "titel": "OWee-video op de voorpagina laadt nu direct",
+      "beschrijving": "De video stond in 4K op de website en was 75 MB groot, waardoor hij de eerste seconden bleef hangen. Hij wordt nu automatisch kleiner geleverd (5 MB) en je ziet meteen het eerste beeld.",
+      "categorie": "bugfix",
+      "grootte": "klein",
+      "auteur": "Jefry"
+    },
+    {
       "id": "content-zomerthema-uit",
       "datum": "15-08-2026",
       "titel": "Zomerthema uitgezet",

--- a/src/pages/home/components/HeroVideo.tsx
+++ b/src/pages/home/components/HeroVideo.tsx
@@ -21,8 +21,26 @@ import { useEffect } from "react";
 import "./HeroVideo.scss";
 import logo from "$images/logo.png";
 
-const HERO_VIDEO_URL =
-  "https://res.cloudinary.com/dknah0nov/video/upload/v1786804828/Dodeka_OWee_2026_teaser.mp4";
+// Cloudinary serves the raw upload untouched unless the URL carries a
+// transformation segment. The source file is 3840x2160, 75 MB for 15 seconds —
+// an average of 41.7 Mbps, which no normal connection can stream in real time,
+// so the hero sat frozen while it buffered.
+//
+// These transformations are applied on delivery and cached by Cloudinary, so
+// the original upload does not need re-encoding or replacing:
+//   f_auto          best format per browser (WebM/VP9 to Chrome, MP4 to Safari)
+//   q_auto          quality chosen per frame content
+//   w_1920,c_limit  cap the width at 1920, never upscale
+const CLOUDINARY_BASE = "https://res.cloudinary.com/dknah0nov/video/upload";
+const HERO_VIDEO_ID = "v1786804828/Dodeka_OWee_2026_teaser";
+
+// 5.2 MB at 2.9 Mbps, down from 75 MB at 41.7 Mbps.
+const HERO_VIDEO_URL = `${CLOUDINARY_BASE}/f_auto,q_auto,w_1920,c_limit/${HERO_VIDEO_ID}.mp4`;
+
+// The first frame as a still (~63 KB, `so_0` = start offset 0). It paints
+// straight away and covers the gap while the video buffers, so the hero never
+// shows a black box.
+const HERO_POSTER_URL = `${CLOUDINARY_BASE}/so_0,f_auto,q_auto,w_1920,c_limit/${HERO_VIDEO_ID}.jpg`;
 
 function HeroVideo() {
   useEffect(() => {
@@ -59,6 +77,8 @@ function HeroVideo() {
       <video
         id="hero_video_element"
         src={HERO_VIDEO_URL}
+        poster={HERO_POSTER_URL}
+        preload="auto"
         autoPlay
         muted
         loop


### PR DESCRIPTION
Turns the home page into the OWee setup for the intro week, and switches the summer theme off.

## What changed

**Hero video** — a fullscreen video sits above the navigation bar on the home page. The nav is already `position: sticky`, so it simply starts below the fold and slides into place as you scroll past the video; no scroll handler drives it. The big home logo is `position: fixed`, so the hero publishes a `--hero-offset` variable that the logo's `top` adds, letting it ride down with the nav instead of floating over the video.

**OWee banner** — the dormant `HomePromo` component is enabled and restyled: a navy date chip, headline, and circular arrow CTA over diagonal track-lane texture. It sits under the title bar and pins below the nav once scrolled past.

**Summer theme off** — the falling emoji and the sand bar are now behind a single `SEASON_THEME_ENABLED` flag in `src/pages/home/season.ts`.

## Two things worth reviewing

- `#app_flex` changed from `overflow: hidden` to `overflow: clip` in `layout.css`. `hidden` makes the element a scroll container, which silently stops **any** `position: sticky` inside the page content from working — the banner would not pin at all. `clip` clips identically without that side effect. Checked for horizontal overflow across nine routes at 390px and 1280px: none.
- The Cloudinary hero URL carried no transformation, so the raw upload was served as-is: 3840x2160, 75 MB for 15 seconds, averaging 41.7 Mbps, which stalled on load. Adding `f_auto,q_auto,w_1920,c_limit` brings it to 1920x1080 and 5.2 MB (2.9 Mbps) with no re-upload, plus a 63 KB first-frame poster.

## Verification

- Sticky behaviour measured at each scroll position: the banner flows with the page and pins at exactly 64px, flush under the nav.
- Layout checked at 320px, 390px and 1280px — no clipping, no title/CTA collision, no horizontal overflow, 44px tap target.
- Contrast measured in-browser: the navy chip is 16.3:1 and the banner text 4.55:1, both clear of 4.5:1.
- Hero title uses `text-wrap: balance`; word-per-line counts verified from 320px up so the last line never strands a single word.
- Video and poster sizes confirmed by downloading each variant from Cloudinary.
- The removal steps documented in `CLAUDE.md` were checked by performing them (deleting the hero also requires dropping `isHome`, which otherwise trips TS6133).
- `npm run check` reports no new errors; pre-existing `AdminOld`/`LedenOld` and test-file errors are untouched.

## Turning it off again

`CLAUDE.md` now has an "OWee mode" section covering how to remove the hero video, the banner, and the OWee nav item, plus which adjacent changes are general fixes that should stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)