### PR TITLE
OWee-planning: popup over de planning, meer lucht en duidelijke knoppen

### DIFF
--- a/src/content/Changelog.json
+++ b/src/content/Changelog.json
@@ -1,16 +1,6 @@
 {
   "updates": [
     {
-      "id": "verbetering-owee-planning",
-      "datum": "16-08-2026",
-      "titel": "OWee-planning: pop-up over de planning en een knop naar het interesseformulier",
-      "beschrijving": "Klik je een activiteit aan, dan opent de info nu als pop-up over de planning heen in plaats van de planning te vervangen, en sluit je hem met een klik ernaast of met Escape. Bij elke activiteit staat voortaan een rood labeltje 'Klik voor meer info', en onder de planning zit een knop naar het interesseformulier.",
-      "categorie": "verbetering",
-      "grootte": "klein",
-      "auteur": "Jefry",
-      "link": "/owee"
-    },
-    {
       "id": "bugfix-owee-video-sneller",
       "datum": "15-08-2026",
       "titel": "OWee-video op de voorpagina laadt nu direct",

--- a/src/content/Changelog.json
+++ b/src/content/Changelog.json
@@ -1,6 +1,16 @@
 {
   "updates": [
     {
+      "id": "verbetering-owee-planning",
+      "datum": "16-08-2026",
+      "titel": "OWee-planning: pop-up over de planning en een knop naar het interesseformulier",
+      "beschrijving": "Klik je een activiteit aan, dan opent de info nu als pop-up over de planning heen in plaats van de planning te vervangen, en sluit je hem met een klik ernaast of met Escape. Bij elke activiteit staat voortaan een rood labeltje 'Klik voor meer info', en onder de planning zit een knop naar het interesseformulier.",
+      "categorie": "verbetering",
+      "grootte": "klein",
+      "auteur": "Jefry",
+      "link": "/owee"
+    },
+    {
       "id": "bugfix-owee-video-sneller",
       "datum": "15-08-2026",
       "titel": "OWee-video op de voorpagina laadt nu direct",

--- a/src/pages/owee/components/OWeeInteresse.scss
+++ b/src/pages/owee/components/OWeeInteresse.scss
@@ -1,0 +1,97 @@
+@use "../../../variables";
+
+.OWeeInteresse {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 0.75rem;
+    padding: 0 4rem;
+    margin-bottom: 4rem;
+    @include variables.respond(mobile) {
+        padding: 0 1rem;
+        margin-bottom: 2rem;
+    }
+}
+
+.OWeeInteresseTitel {
+    font-size: variables.$font_ml;
+    font-weight: variables.$bold;
+    color: variables.$dodeka_blauw;
+    @include variables.respond(mobile) {
+        font-size: variables.$font_medium;
+    }
+}
+
+.OWeeInteresseTekst {
+    max-width: 34rem;
+    font-size: variables.$font_small;
+    line-height: variables.$line_height_small;
+    color: variables.$dodeka_blauw;
+}
+
+.OWeeInteresseKnop {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    // Ruim boven de 44px die een vinger nodig heeft.
+    min-height: 3.25rem;
+    padding: 0.75rem 1.75rem;
+    margin-top: 0.25rem;
+
+    border-radius: 0.75rem;
+    background: linear-gradient(
+        100deg,
+        variables.$dodeka_rood 0%,
+        variables.$baan_rood 100%
+    );
+    box-shadow: 0 0.25rem 0.75rem rgba(0, 31, 72, 0.25);
+
+    color: white;
+    font-size: variables.$font_medium;
+    font-weight: variables.$bold;
+    text-decoration: none;
+
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+    transition:
+        transform 150ms ease-out,
+        box-shadow 150ms ease-out;
+
+    &:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 0.5rem 1.25rem rgba(0, 31, 72, 0.3);
+    }
+
+    &:active {
+        transform: translateY(0) scale(0.98);
+    }
+
+    &:focus-visible {
+        outline: 3px solid variables.$dodeka_blauw;
+        outline-offset: 3px;
+    }
+}
+
+.OWeeInteresseKnopPijl {
+    height: 1rem;
+    fill: white;
+    transition: transform 150ms ease-out;
+}
+
+.OWeeInteresseKnop:hover .OWeeInteresseKnopPijl {
+    transform: translateX(0.25rem);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .OWeeInteresseKnop,
+    .OWeeInteresseKnopPijl {
+        transition: none;
+    }
+
+    .OWeeInteresseKnop:hover,
+    .OWeeInteresseKnop:active,
+    .OWeeInteresseKnop:hover .OWeeInteresseKnopPijl {
+        transform: none;
+    }
+}

--- a/src/pages/owee/components/OWeeInteresse.tsx
+++ b/src/pages/owee/components/OWeeInteresse.tsx
@@ -1,0 +1,34 @@
+import "./OWeeInteresse.scss";
+
+// Staat direct onder de planning: daar is iemand net door alle activiteiten
+// gescrold en is de vraag "en hoe doe ik mee?" op zijn sterkst.
+function OWeeInteresse() {
+    return (
+        <div className="OWeeInteresse">
+            <h2 className="OWeeInteresseTitel">Interesse gekregen?</h2>
+            <p className="OWeeInteresseTekst">
+                Super leuk! Vul het interesseformulier in, dan krijg je
+                informatie over hoe je eventueel lid kan worden en over onze
+                proeftrainingen!
+            </p>
+            <a
+                className="OWeeInteresseKnop"
+                href="https://docs.google.com/forms/d/e/1FAIpQLSc4xozvdVigejC7rAnqe9x41SFxnAe6YvS4cNgLsiTQOP8bDQ/viewform"
+                target="_blank"
+                rel="noreferrer"
+            >
+                Vul het interesseformulier in
+                <svg
+                    className="OWeeInteresseKnopPijl"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                >
+                    <path d="M13.025 1l-2.847 2.828 6.176 6.176h-16.354v3.992h16.354l-6.176 6.176 2.847 2.828 10.975-11z" />
+                </svg>
+            </a>
+        </div>
+    );
+}
+
+export default OWeeInteresse;

--- a/src/pages/owee/components/OWeeInteresse.tsx
+++ b/src/pages/owee/components/OWeeInteresse.tsx
@@ -1,7 +1,19 @@
 import "./OWeeInteresse.scss";
 
-// Staat direct onder de planning: daar is iemand net door alle activiteiten
-// gescrold en is de vraag "en hoe doe ik mee?" op zijn sterkst.
+/*
+ * De knop naar het interesseformulier, direct onder de planning: daar is iemand
+ * net door alle activiteiten gescrold en is de vraag "en hoe doe ik mee?" op
+ * zijn sterkst.
+ *
+ * Nieuw formulier volgend jaar? Vervang de href hieronder. Gebruik bij Google
+ * Formulieren de deel-link (Verzenden -> het linkje), die eindigt op /viewform.
+ * De link uit de adresbalk terwijl je het formulier bewerkt eindigt op /edit en
+ * werkt niet voor bezoekers.
+ *
+ * De tekst van de titel, het tussenzinnetje en het knoplabel staan hieronder
+ * gewoon als tekst. Vormgeving: OWeeInteresse.scss.
+ * Dit blok wordt op de pagina gezet in owee.tsx.
+ */
 function OWeeInteresse() {
     return (
         <div className="OWeeInteresse">

--- a/src/pages/owee/components/OWeeSchema.scss
+++ b/src/pages/owee/components/OWeeSchema.scss
@@ -101,9 +101,10 @@
     }
 }
 
-// Rood labeltje onderin de activiteit. Staat er altijd, zodat ook wie niet met
-// de muis over de kaart gaat ziet dat er meer info achter zit.
-.OWeeTooltip {
+// Het rode "Klik voor meer info"-labeltje onderin elke activiteit. Het staat er
+// altijd (dus niet alleen bij hover), zodat ook op mobiel en voor wie niet met
+// de muis over de kaart gaat duidelijk is dat er meer info achter zit.
+.OWeeActiviteitInfo {
     display: inline-block;
     margin-top: 0.75rem;
 
@@ -119,8 +120,8 @@
     transition: background-color 0.2s ease;
 }
 
-.OWeeActiviteit:hover .OWeeTooltip,
-.OWeeActiviteit:focus-visible .OWeeTooltip {
+.OWeeActiviteit:hover .OWeeActiviteitInfo,
+.OWeeActiviteit:focus-visible .OWeeActiviteitInfo {
     background-color: variables.$baan_rood;
 }
 

--- a/src/pages/owee/components/OWeeSchema.scss
+++ b/src/pages/owee/components/OWeeSchema.scss
@@ -6,8 +6,6 @@
     background-repeat: no-repeat;
     background-size: cover;
     background-position: center;
-    border-top: 4rem solid variables.$dodeka_blauw90p;
-    border-bottom: 4rem solid variables.$dodeka_blauw90p;
     width: 100%;
     // Ruimer kader dan voorheen (1rem / 4rem / 3rem): zo blijft er aan alle
     // kanten een rand van de achtergrondfoto zichtbaar rond de planning.
@@ -28,8 +26,6 @@
         flex-direction: column;
         overflow-x: scroll;
         scroll-snap-type: x mandatory;
-        border-top: 2rem solid variables.$dodeka_blauw90p;
-        border-bottom: 2rem solid variables.$dodeka_blauw90p;
     }
 }
 
@@ -90,9 +86,15 @@
     margin: 0 0 0.75rem;
     position: relative;
     cursor: pointer;
-    transition: transform 0.2s ease;
+    box-shadow: 0 2px 8px rgba(0, 31, 72, 0.15);
+    transition:
+        transform 0.15s ease-out,
+        box-shadow 0.15s ease-out;
+    // Was scale(1.05): in de smallere kolommen liep een opgeschaalde kaart over
+    // zijn buren heen. Een klein zetje omhoog leest net zo goed als "klikbaar".
     &:hover {
-        transform: scale(1.05);
+        transform: translateY(-3px);
+        box-shadow: 0 0.5rem 1.25rem rgba(0, 31, 72, 0.3);
     }
     &:last-child {
         margin-bottom: 0;
@@ -126,14 +128,6 @@
     font-size: variables.$font_medium;
     color: white;
     // font-weight: $normal;
-}
-
-.OWeeActiviteit:hover {
-    margin: 1rem;
-}
-
-.OWeeActiviteit:active{
-    margin: 1rem;
 }
 
 .OWeeActiviteitTijd {

--- a/src/pages/owee/components/OWeeSchema.scss
+++ b/src/pages/owee/components/OWeeSchema.scss
@@ -225,6 +225,74 @@
     flex: 1;
 }
 
+// Aanmeldknop in de Training/Runclub-popups: dezelfde rood-verloop-CTA als de
+// interesseformulier-knop onder de planning, zodat "hier moet je iets doen"
+// er in de hele OWee-pagina hetzelfde uitziet.
+.OWeeInschrijfKnop {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    min-height: 3rem;
+    padding: 0.65rem 1.5rem;
+    margin-top: 1rem;
+
+    border-radius: 0.75rem;
+    background: linear-gradient(
+        100deg,
+        variables.$dodeka_rood 0%,
+        variables.$baan_rood 100%
+    );
+    box-shadow: 0 0.25rem 0.75rem rgba(0, 31, 72, 0.25);
+
+    color: white;
+    font-size: variables.$font_small;
+    font-weight: variables.$bold;
+    text-decoration: none;
+
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+    transition:
+        transform 150ms ease-out,
+        box-shadow 150ms ease-out;
+
+    &:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 0.5rem 1.25rem rgba(0, 31, 72, 0.3);
+    }
+
+    &:active {
+        transform: translateY(0) scale(0.98);
+    }
+
+    &:focus-visible {
+        outline: 3px solid variables.$dodeka_blauw;
+        outline-offset: 3px;
+    }
+}
+
+.OWeeInschrijfKnopPijl {
+    height: 0.9rem;
+    fill: white;
+    transition: transform 150ms ease-out;
+}
+
+.OWeeInschrijfKnop:hover .OWeeInschrijfKnopPijl {
+    transform: translateX(0.25rem);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .OWeeInschrijfKnop,
+    .OWeeInschrijfKnopPijl {
+        transition: none;
+    }
+
+    .OWeeInschrijfKnop:hover,
+    .OWeeInschrijfKnop:active,
+    .OWeeInschrijfKnop:hover .OWeeInschrijfKnopPijl {
+        transform: none;
+    }
+}
+
 .OWeeImagePopup {
     width: 45%;
     border-radius: 0.5rem;

--- a/src/pages/owee/components/OWeeSchema.scss
+++ b/src/pages/owee/components/OWeeSchema.scss
@@ -77,10 +77,35 @@
     padding: 1rem;
     margin-bottom: 1rem;
     margin: 1rem;
+    position: relative;
+    cursor: pointer;
     transition: transform 0.2s ease;
     &:hover {
         transform: scale(1.05);
     }
+}
+
+// Rood labeltje onderin de activiteit. Staat er altijd, zodat ook wie niet met
+// de muis over de kaart gaat ziet dat er meer info achter zit.
+.OWeeTooltip {
+    display: inline-block;
+    margin-top: 0.75rem;
+
+    background-color: variables.$dodeka_rood;
+    color: white;
+    border-radius: 0.5rem;
+    // Net klein genoeg om in de smalle dagkolommen op één regel te passen.
+    padding: 0.35rem 0.6rem;
+    font-size: 0.8rem;
+    font-weight: variables.$bold;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+
+    transition: background-color 0.2s ease;
+}
+
+.OWeeActiviteit:hover .OWeeTooltip,
+.OWeeActiviteit:focus-visible .OWeeTooltip {
+    background-color: variables.$baan_rood;
 }
 
 .OWeeActiviteitNaam {
@@ -122,8 +147,26 @@
     border-radius: 1rem;
 }
 
-.hidden {
-    display: none;
+// Verduisterde laag over de hele pagina; de planning blijft er onder zichtbaar.
+.popupOverlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem 1rem;
+    overflow-y: auto;
+
+    background-color: rgba(0, 31, 72, 0.6);
+    animation: OWeeOverlayFade 0.15s ease;
+}
+
+@keyframes OWeeOverlayFade {
+    from {
+        opacity: 0;
+    }
 }
 
 .popup {
@@ -132,7 +175,12 @@
     border-radius: 1rem;
     padding: 3.5rem 2rem 2rem;
     max-width: 800px;
-    margin: 0 auto;
+    width: 100%;
+    max-height: 100%;
+    overflow-y: auto;
+    margin: auto;
+    box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.35);
+    cursor: default;
 }
 
 .popupContent {
@@ -168,8 +216,11 @@
 }
 
 @media (max-width: 600px) {
+    .popupOverlay {
+        padding: 1rem;
+    }
     .popup {
-        margin: 0 1rem;
+        padding: 3rem 1.25rem 1.5rem;
     }
     .popupContent {
         flex-direction: column;

--- a/src/pages/owee/components/OWeeSchema.scss
+++ b/src/pages/owee/components/OWeeSchema.scss
@@ -167,7 +167,13 @@
     box-shadow: 0 1rem 2rem rgba(0, 31, 72, 0.2);
 
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
+    // Elke dag (.OWeeDag) krijgt automatisch een even brede kolom. Het aantal
+    // dagen staat dus nergens vast: haal je er een dag bij of weg in
+    // OWeeSchema.tsx, dan klopt deze indeling vanzelf weer.
+    grid-auto-flow: column;
+    // minmax(0, 1fr) in plaats van 1fr: zo blijven alle kolommen even breed,
+    // ook als er in één activiteit een lang adres of een lange naam staat.
+    grid-auto-columns: minmax(0, 1fr);
     gap: 2.5rem;
     padding: 1.5rem;
 

--- a/src/pages/owee/components/OWeeSchema.scss
+++ b/src/pages/owee/components/OWeeSchema.scss
@@ -130,6 +130,15 @@
     // font-weight: $normal;
 }
 
+// Voor titels met een locatie erin ("Sportfeest @ Proteus"): het venue is
+// ondergeschikt aan de activiteitnaam en mag kleiner, zodat de titel op één
+// regel past in de smalle dagkolom.
+.OWeeActiviteitNaamVenue {
+    font-size: variables.$font_small;
+    font-weight: variables.$normal;
+    white-space: nowrap;
+}
+
 .OWeeActiviteitTijd {
     font-size: variables.$font_small;
     padding-top: 0.5rem;

--- a/src/pages/owee/components/OWeeSchema.scss
+++ b/src/pages/owee/components/OWeeSchema.scss
@@ -9,17 +9,19 @@
     border-top: 4rem solid variables.$dodeka_blauw90p;
     border-bottom: 4rem solid variables.$dodeka_blauw90p;
     width: 100%;
-    padding-top: 1rem;
+    // Ruimer kader dan voorheen (1rem / 4rem / 3rem): zo blijft er aan alle
+    // kanten een rand van de achtergrondfoto zichtbaar rond de planning.
+    padding-top: 2rem;
     padding-left: 4rem;
-    padding-right: 3rem;
-    padding-bottom: 1rem;
+    padding-right: 4rem;
+    padding-bottom: 3rem;
     // Was 8rem: de interesse-knop staat nu in dat gat en zorgt zelf voor de
     // ruimte richting de tekst eronder.
     margin-bottom: 3rem;
     @include variables.respond(mobile) {
         padding-top: 1rem;
         padding-left: 1rem;
-        padding-right: 0;
+        padding-right: 1rem;
         padding-bottom: 1rem;
         margin-bottom: 2rem;
         display: flex;
@@ -42,34 +44,40 @@
     font-size: variables.$font_large;
     color: variables.$dodeka_rood;
     -webkit-text-stroke: 1px white;
+    margin-bottom: 1.25rem;
 }
 
 .OWeeDag {
-    display: inline-block;
-    width: calc(20% - 1rem);
     color: variables.$dodeka_blauw90p;
-    vertical-align: top;
-    margin-right: 1rem;
-    padding-right: 1rem;
+    // De breedte en de tussenruimte komen van de grid op .planning; de kolom
+    // zelf hoeft alleen zijn eigen inhoud te stapelen.
     @include variables.respond(mobile) {
-        display: auto;
         width: 100%;
         min-width: 80vw;
     }
 }
 
+// Op mobiel staan de dagen onder elkaar en valt de grid-gap weg; deze marge
+// houdt de dagen net zo duidelijk uit elkaar als op desktop.
+.OWeeDag + .OWeeDag {
+    @include variables.respond(mobile) {
+        margin-top: 2rem;
+    }
+}
+
+// Dag en datum horen bij elkaar en staan daarom dicht op elkaar; de ruimte
+// eronder (1.25rem) is groter, zodat de kop bij zijn eigen kolom hoort en niet
+// tussen de dagen in lijkt te zweven.
 .OWeeDatum {
     color: variables.$dodeka_blauw;
     font-size: variables.$font_medium;
-    //margin: top right bottom left;
-    //margin-bottom: 1rem;
-    margin: 1rem 0 0 1rem;
+    margin: 0.125rem 0 1.25rem;
     font-weight: variables.$bold;
 }
 
 .OWeeDatumDag {
     font-size: variables.$font_ml;
-    margin: 0 0 1rem 1rem;
+    margin: 0;
     font-weight: variables.$bold;
 }
 
@@ -77,13 +85,17 @@
     background-color: variables.$dodeka_blauw90p;
     border-radius: 0.5rem;
     padding: 1rem;
-    margin-bottom: 1rem;
-    margin: 1rem;
+    // Activiteiten binnen één dag staan dichter op elkaar dan de dagen onderling
+    // (de grid-gap van .planning).
+    margin: 0 0 0.75rem;
     position: relative;
     cursor: pointer;
     transition: transform 0.2s ease;
     &:hover {
         transform: scale(1.05);
+    }
+    &:last-child {
+        margin-bottom: 0;
     }
 }
 
@@ -133,7 +145,6 @@
 
 .OWeeActiviteitPlaats {
     font-size: variables.$font_small;
-    padding-bottom: 0.5rem;
     color: white;
     // font-weight: $bold;
 }
@@ -145,8 +156,24 @@
 }
 
 .planning {
-    background-color: white;
+    // Iets doorschijnend: de achtergrondfoto blijft door de planning heen
+    // zichtbaar in plaats van volledig weggedekt te worden door een wit vlak.
+    background-color: rgba(255, 255, 255, 0.9);
+    backdrop-filter: blur(3px);
     border-radius: 1rem;
+    box-shadow: 0 1rem 2rem rgba(0, 31, 72, 0.2);
+
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 2.5rem;
+    padding: 1.5rem;
+
+    @include variables.respond(mobile) {
+        display: block;
+        padding: 1rem;
+        background-color: white;
+        backdrop-filter: none;
+    }
 }
 
 // Verduisterde laag over de hele pagina; de planning blijft er onder zichtbaar.

--- a/src/pages/owee/components/OWeeSchema.scss
+++ b/src/pages/owee/components/OWeeSchema.scss
@@ -13,13 +13,15 @@
     padding-left: 4rem;
     padding-right: 3rem;
     padding-bottom: 1rem;
-    margin-bottom: 8rem;
+    // Was 8rem: de interesse-knop staat nu in dat gat en zorgt zelf voor de
+    // ruimte richting de tekst eronder.
+    margin-bottom: 3rem;
     @include variables.respond(mobile) {
         padding-top: 1rem;
         padding-left: 1rem;
         padding-right: 0;
         padding-bottom: 1rem;
-        margin-bottom: 4rem;
+        margin-bottom: 2rem;
         display: flex;
         flex-direction: column;
         overflow-x: scroll;

--- a/src/pages/owee/components/OWeeSchema.tsx
+++ b/src/pages/owee/components/OWeeSchema.tsx
@@ -10,8 +10,52 @@ import trackFestival from "$images/owee/track_festival.webp";
 import training_rennen from "$images/owee/training_rennen.webp";
 import run from "$images/owee/run.webp";
 
-
-
+/*
+ * DE OWEE-PLANNING AANPASSEN (bijv. voor volgend jaar)
+ * ====================================================
+ *
+ * Elke activiteit staat op TWEE plekken in dit bestand:
+ *
+ *   1. Het kaartje in de planning        -> hieronder, binnen een <div className="OWeeDag">
+ *   2. De popup met de uitleg + foto     -> verderop, onder "POPUPS"
+ *
+ * Die twee horen bij elkaar via een sleutelwoord. Op het kaartje staat
+ * setShowPopup("Borrel") en bij de popup showPopup === "Borrel". Zolang die
+ * twee exact hetzelfde zijn (hoofdletters tellen mee!) opent het juiste
+ * verhaal. Typ je ze verschillend, dan gebeurt er bij het klikken niets.
+ *
+ * Alleen tijden, plaatsen of teksten wijzigen?
+ *   Dat is gewoon tekst: pas de regels in het kaartje of in de popup aan.
+ *   Er is geen aparte lijst of database, alles staat letterlijk hier.
+ *
+ * Een activiteit TOEVOEGEN:
+ *   1. Kopieer een bestaand <div className="OWeeActiviteit"> ... </div> blok
+ *      naar de dag waar het bij hoort en pas de tekst aan.
+ *   2. Verzin een nieuw sleutelwoord, bijv. setShowPopup("Pubquiz").
+ *   3. Kopieer onder "POPUPS" een bestaand blok en zet daar showPopup === "Pubquiz".
+ *   4. Foto: zet het bestand in src/images/owee/ en voeg bovenaan een import
+ *      toe (kijk naar de regels hierboven), gebruik hem dan in <img src={...} />.
+ *
+ * Een activiteit WEGHALEN: verwijder allebei de blokken (kaartje + popup).
+ *
+ * Een DAG toevoegen of weghalen: kopieer/verwijder een heel
+ * <div className="OWeeDag"> ... </div> blok. De kolommen verdelen zichzelf,
+ * je hoeft niets aan de opmaak te veranderen.
+ *
+ * Let op: "Training" staat twee keer in de planning (maandag en woensdag) en
+ * gebruikt beide keren dezelfde sleutel, dus samen één popup. Moet er voor één
+ * van de twee iets anders in de popup staan, geef die dan een eigen sleutel.
+ *
+ * Een INSCHRIJFKNOP in een popup (zoals bij Training en Runclub): kopieer het
+ * <a className="OWeeInschrijfKnop"> ... </a> blok en zet de juiste link in href.
+ * Gebruik bij Google Formulieren de deel-link (die eindigt op /viewform), niet
+ * de link uit de adresbalk terwijl je het formulier aan het bewerken bent (die
+ * eindigt op /edit) — die werkt niet voor bezoekers.
+ *
+ * Kleuren, afstanden en de vormgeving staan in OWeeSchema.scss.
+ * De knop naar het interesseformulier onder de planning is een los bestand:
+ * OWeeInteresse.tsx.
+ */
 
 function OWeeSchema() {
     const [showPopup, setShowPopup] = useState<string | null>(null);
@@ -119,8 +163,14 @@ function OWeeSchema() {
                     </div>
                 </div>
             </div>
-            {/* De popup ligt als overlay over de planning heen. Klik naast de
-                popup (op de overlay zelf) om hem te sluiten. */}
+            {/* ======================= POPUPS =======================
+                Hieronder staat per activiteit het verhaal dat verschijnt als je
+                op het kaartje klikt. Er zijn twee lagen:
+                  .popupOverlay = de donkere laag over de hele pagina; klik je
+                                  daarop (dus naast de popup), dan sluit hij.
+                  .popup        = het witte kaartje zelf; een klik hierbinnen
+                                  sluit juist niet (dat doet stopPropagation).
+                Sluiten kan ook met het kruisje of met de Escape-toets. */}
             {showPopup !== null && (
                 <div className="popupOverlay" onClick={() => setShowPopup(null)}>
                 <div
@@ -260,7 +310,7 @@ function OWeeSchema() {
                         </div>
                         </>
                     )}
-                </div>
+                </div>{/* einde .popup (het witte kaartje) */}
                 </div>
             )}
             

--- a/src/pages/owee/components/OWeeSchema.tsx
+++ b/src/pages/owee/components/OWeeSchema.tsx
@@ -273,7 +273,7 @@ function OWeeSchema() {
                         <div className="popupContent">
                             <div className="popupText">
                                 <h2>Sportfeest bij Proteus</h2>
-                                <p>Dodeka is natuurlijk niet te missen bij het sportfeest op proteus. Hier kun je zien dat Dodeka niet alleen een sportvereniging is maar ook super gezellig.</p>
+                                <p>Dodeka is natuurlijk niet te missen bij het sportfeest op Proteus. Hier kun je zien dat Dodeka niet alleen een sportvereniging is maar ook super gezellig.</p>
                             </div>
                             <img className="OWeeImagePopup" src={sportfeest} />
                         </div>

--- a/src/pages/owee/components/OWeeSchema.tsx
+++ b/src/pages/owee/components/OWeeSchema.tsx
@@ -121,7 +121,7 @@ function OWeeSchema() {
                 </div>
                 <div className="OWeeDag">
                     <h1 className="OWeeDatumDag">Dinsdag</h1>
-                    <h1 className="OWeeDatum">19 augustus</h1>
+                    <h1 className="OWeeDatum">18 augustus</h1>
                     <div className="OWeeActiviteit" onClick={() => setShowPopup("Runclub")}>
                         <h1 className="OWeeActiviteitNaam">Runclub</h1>
                         <p className="OWeeActiviteitTijd">10:30-11:30</p>
@@ -137,7 +137,7 @@ function OWeeSchema() {
                 </div>
                 <div className="OWeeDag">
                     <h1 className="OWeeDatumDag">Woensdag</h1>
-                    <h1 className="OWeeDatum">20 augustus</h1>
+                    <h1 className="OWeeDatum">19 augustus</h1>
                     <div className="OWeeActiviteit" onClick={() => setShowPopup("Act_markt")}>
                         <h1 className="OWeeActiviteitNaam">Activiteitenmarkt </h1>
                         <p className="OWeeActiviteitTijd">11:00-15:00</p>
@@ -159,7 +159,7 @@ function OWeeSchema() {
                 </div>
                 <div className="OWeeDag">
                     <h1 className="OWeeDatumDag">Donderdag</h1>
-                    <h1 className="OWeeDatum">21 augustus</h1>
+                    <h1 className="OWeeDatum">20 augustus</h1>
                     <div className="OWeeActiviteit" onClick={() => setShowPopup("Chilldag")}>
                         <h1 className="OWeeActiviteitNaam">Delftse Hout relax</h1>
                         <p className="OWeeActiviteitTijd">11:30-13:00</p>
@@ -194,7 +194,7 @@ function OWeeSchema() {
                         <div className="popupContent">
                             <div className="popupText">
                                 <h2>Parade</h2>
-                                <p>De eerst Owee activiteit waar dodeka te vinden is met een beeldschone prachtige en zeker veilige parade kar is de parade, wij zullen ons in een stoet van verenigingen voortbewegen langs de Schie. Zwaaien is toegestaan.</p>
+                                <p>De eerste OWee-activiteit waar Dodeka te vinden is met een beeldschone prachtige en zeker veilige paradekar is de parade, wij zullen ons in een stoet van verenigingen voortbewegen langs de Schie. Zwaaien is toegestaan.</p>
                             </div>
                             <img className="OWeeImagePopup" src={parade} />
                         </div>
@@ -206,7 +206,7 @@ function OWeeSchema() {
                         <div className="popupContent">
                             <div className="popupText">
                                 <h2>Openingsfeest</h2>
-                                <p>Na de parade, is Dodeka natuurlijk ook bij het openingsfeest. Hier kun je al een kleine sneak peak krijgen van hoe leuk Dodeka is, buiten het sporten om </p>
+                                <p>Na de parade is Dodeka natuurlijk ook bij het openingsfeest. Hier kun je al een kleine sneak peek krijgen van hoe leuk Dodeka is, buiten het sporten om.</p>
                             </div>
                             <img className="OWeeImagePopup" src={trackFestival} />
                         </div>
@@ -218,7 +218,7 @@ function OWeeSchema() {
                         <div className="popupContent">
                             <div className="popupText">
                                 <h2>Infomarkt</h2>
-                                <p>Op maandag wordt de markt van Delft omgetoverd tot een verenigings informatie walhalla. Met een in dodeka stijl opgemaakte kraam zijn wij hier te vinden. Onze leden zijn aanwezig om je alles te vertellen over onze prACHTige vereniging. Kom langs, stel al je vragen, doe mee aan een reactie spelletje of een prijsvraag en geniet van deze eerste dag van de OWee</p>
+                                <p>Op maandag wordt de markt van Delft omgetoverd tot een walhalla van verenigingsinformatie. Met een in Dodeka-stijl opgemaakte kraam zijn wij hier te vinden. Onze leden zijn aanwezig om je alles te vertellen over onze prachtige vereniging. Kom langs, stel al je vragen, doe mee aan een reactiespelletje of een prijsvraag en geniet van deze eerste dag van de OWee.</p>
                             </div>
                             <img className="OWeeImagePopup" src={infomarkt} />
                         </div>
@@ -230,7 +230,7 @@ function OWeeSchema() {
                         <div className="popupContent">
                             <div className="popupText">
                                 <h2>Training</h2>
-                                <p>De maandag en woensdag kan worden afgesloten met een sportieve training bij ons op de atletiekbaan, op het adres Sportring 12. Proeftrainen kan 3 keer gratis en zelfs tijdens de OWee! </p>
+                                <p>De maandag en woensdag kunnen worden afgesloten met een sportieve training bij ons op de atletiekbaan, op het adres Sportring 12. Proeftrainen kan 3 keer gratis en zelfs tijdens de OWee! </p>
                                 {/* Verwijst naar onze eigen trainingenpagina; daar staat alles
                                     over de trainingen en het proeftrainen. <Link> in plaats van
                                     <a> houdt het binnen de site (geen herlaadbeurt). */}
@@ -251,7 +251,7 @@ function OWeeSchema() {
                         <div className="popupContent">
                             <div className="popupText">
                                 <h2>Runclub</h2>
-                                <p>Voor de OWee loper die een Owee renner wil worden hebben we dit jaar een primeur: Dodeka Runclub! Op dinsdagochtend zullen we om 10:30 verzamelen op de markt. Vanaf hier wordt, samen met leden van Dodeka op een rustig tempo een rondje van 5km gelopen door Delft. Krijg alvast een beeld van de stad, leer wat dodekaëders kennen en geniet van een ontspannen sportieve sfeer.</p>
+                                <p>Voor de OWee-loper die een OWee-renner wil worden hebben we dit jaar een primeur: Dodeka Runclub! Op dinsdagochtend zullen we om 10:30 verzamelen op de markt. Vanaf hier wordt, samen met leden van Dodeka op een rustig tempo een rondje van 5 km gelopen door Delft. Krijg alvast een beeld van de stad, leer wat dodekaëders kennen en geniet van een ontspannen sportieve sfeer.</p>
                                 <br></br>
                                 <p>Onderweg zal er gestopt worden bij kaaslokaal Delft om te genieten van een gratis blokje kaas. Na deze korte pauze gaat de run verder, we eindigen bij Piada at the canal, waar deelnemers die het tot het einde hebben gehaald beloond worden met een gratis Piade. </p>
                                 <br></br>
@@ -273,7 +273,7 @@ function OWeeSchema() {
                         <div className="popupContent">
                             <div className="popupText">
                                 <h2>Sportfeest bij Proteus</h2>
-                                <p>Dodeka is natuurlijk niet te missen bij het sportfeest op proteus. Hier kun je zien dat dodeka niet alleen een sportvereniging is maar ook super gezellig.</p>
+                                <p>Dodeka is natuurlijk niet te missen bij het sportfeest op proteus. Hier kun je zien dat Dodeka niet alleen een sportvereniging is maar ook super gezellig.</p>
                             </div>
                             <img className="OWeeImagePopup" src={sportfeest} />
                         </div>
@@ -285,7 +285,7 @@ function OWeeSchema() {
                         <div className="popupContent">
                             <div className="popupText">
                                 <h2>Activiteitenmarkt bij X</h2>
-                                <p>Altijd al eens willen kogelstoten? Of laten zien dat jij de snelste sprinter bent? Tijdens de activiteitenmarkt kan je laagdrempelig deelnemen aan deze onderdelen, ondertussen spreken met dodeka leden en genieten van deze laatste dag van de OWee. </p>
+                                <p>Altijd al eens willen kogelstoten? Of laten zien dat jij de snelste sprinter bent? Tijdens de activiteitenmarkt kan je laagdrempelig deelnemen aan deze onderdelen, ondertussen spreken met Dodeka-leden en genieten van deze laatste dag van de OWee. </p>
                             </div>
                             <img className="OWeeImagePopup" src={activiteitenmarkt
                             } />
@@ -298,7 +298,7 @@ function OWeeSchema() {
                         <div className="popupContent">
                             <div className="popupText">
                                 <h2>Delftse hout relax dag</h2>
-                                <p>Als afsluiter van de Owee wordt er vanaf 11:30 met dodeka ontspannen in het Delftse hout.</p>
+                                <p>Als afsluiter van de OWee wordt er vanaf 11:30 met Dodeka ontspannen in het Delftse Hout.</p>
                             </div>
                             <img className="OWeeImagePopup" src={Chillen_op_gras}/>
                         </div>

--- a/src/pages/owee/components/OWeeSchema.tsx
+++ b/src/pages/owee/components/OWeeSchema.tsx
@@ -1,5 +1,5 @@
 import "./OWeeSchema.scss";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import parade from "$images/owee/parade.webp";
 import activiteitenmarkt from "$images/owee/activiteitenmarkt.webp";
 import borrel from "$images/owee/borrel.webp";
@@ -15,11 +15,29 @@ import run from "$images/owee/run.webp";
 
 function OWeeSchema() {
     const [showPopup, setShowPopup] = useState<string | null>(null);
-    
+
+    // Sluit de popup met Escape, en bevries de pagina eronder zolang hij open staat.
+    useEffect(() => {
+        if (showPopup === null) return;
+
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape") setShowPopup(null);
+        };
+        document.addEventListener("keydown", onKeyDown);
+
+        const vorigeOverflow = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+
+        return () => {
+            document.removeEventListener("keydown", onKeyDown);
+            document.body.style.overflow = vorigeOverflow;
+        };
+    }, [showPopup]);
+
     return(
         <div className="OWeeSchema">
             <h1 className="OWeeHeader">OWEE PLANNING D.S.A.V DODEKA</h1>
-            <div className={showPopup ? "planning hidden" : "planning"}>
+            <div className="planning">
                 <div className="OWeeDag">
                     <h1 className="OWeeDatumDag">Zondag</h1>
                     <h1 className="OWeeDatum">16 augustus</h1>
@@ -27,13 +45,13 @@ function OWeeSchema() {
                         <h1 className="OWeeActiviteitNaam">Parade</h1>
                         <p className="OWeeActiviteitTijd">16:45-19:00</p>
                         <p className="OWeeActiviteitPlaats">Langs de Schie</p>
-                        <p className="OWeeActiviteitPlaats">Klik voor meer info</p>
+                        <span className="OWeeTooltip">Klik voor meer info</span>
                     </div>
                     { <div className="OWeeActiviteit" onClick={() => setShowPopup("Feest")}>
                         <h1 className="OWeeActiviteitNaam">Openingsfeest</h1>
                         <p className="OWeeActiviteitTijd">20:00-01:00</p>
                         <p className="OWeeActiviteitPlaats">Tu Delft Aula</p>
-                        <p className="OWeeActiviteitPlaats">Klik voor meer info</p>
+                        <span className="OWeeTooltip">Klik voor meer info</span>
                     </div>}
                 </div>
                 <div className="OWeeDag">
@@ -43,13 +61,13 @@ function OWeeSchema() {
                         <h1 className="OWeeActiviteitNaam">Infomarkt</h1>
                         <p className="OWeeActiviteitTijd">13:00-17:45</p>
                         <p className="OWeeActiviteitPlaats">Grote Markt</p>
-                        <p className="OWeeActiviteitPlaats">Klik voor meer info</p>
+                        <span className="OWeeTooltip">Klik voor meer info</span>
                     </div>
                     <div className="OWeeActiviteit" onClick={() => setShowPopup("Training")}>
                         <h1 className="OWeeActiviteitNaam">Training</h1>
                         <p className="OWeeActiviteitTijd">18:15-19:45</p>
                         <p className="OWeeActiviteitPlaats">Sportring 12</p>
-                        <p className="OWeeActiviteitPlaats">Klik voor meer info</p>
+                        <span className="OWeeTooltip">Klik voor meer info</span>
                     </div>
                 </div>
                 <div className="OWeeDag">
@@ -59,13 +77,13 @@ function OWeeSchema() {
                         <h1 className="OWeeActiviteitNaam">Runclub</h1>
                         <p className="OWeeActiviteitTijd">10:30-11:30</p>
                         <p className="OWeeActiviteitPlaats">Grote Markt</p>
-                        <p className="OWeeActiviteitPlaats">Klik voor meer info</p>
+                        <span className="OWeeTooltip">Klik voor meer info</span>
                     </div>
                     <div className="OWeeActiviteit" onClick={() => setShowPopup("Sportfeest")}>
                         <h1 className="OWeeActiviteitNaam">Sportfeest bij Proteus</h1>
                         <p className="OWeeActiviteitTijd">20:30-03:00</p>
                         <p className="OWeeActiviteitPlaats">Rotterdamseweg 362a</p>
-                        <p className="OWeeActiviteitPlaats">Klik voor meer info</p>
+                        <span className="OWeeTooltip">Klik voor meer info</span>
                     </div>
                 </div>
                 <div className="OWeeDag">
@@ -75,19 +93,19 @@ function OWeeSchema() {
                         <h1 className="OWeeActiviteitNaam">Activiteitenmarkt </h1>
                         <p className="OWeeActiviteitTijd">11:00-15:00</p>
                         <p className="OWeeActiviteitPlaats">Op X</p>
-                        <p className="OWeeActiviteitPlaats">Klik voor meer info</p>
+                        <span className="OWeeTooltip">Klik voor meer info</span>
                     </div>
                     <div className="OWeeActiviteit" onClick={() => setShowPopup("Training")}>
                         <h1 className="OWeeActiviteitNaam">Training</h1>
                         <p className="OWeeActiviteitTijd">18:15-19:45</p>
                         <p className="OWeeActiviteitPlaats">Sportring 12</p>
-                        <p className="OWeeActiviteitPlaats">Klik voor meer info</p>
+                        <span className="OWeeTooltip">Klik voor meer info</span>
                     </div>
                     <div className="OWeeActiviteit" onClick={() => setShowPopup("Borrel")}>
                         <h1 className="OWeeActiviteitNaam">Borrel</h1>
                         <p className="OWeeActiviteitTijd">20:00-23:00</p>
                         <p className="OWeeActiviteitPlaats">Sportring 12</p>
-                        <p className="OWeeActiviteitPlaats">Klik voor meer info</p>
+                        <span className="OWeeTooltip">Klik voor meer info</span>
                     </div>
                 </div>
                 <div className="OWeeDag">
@@ -97,13 +115,20 @@ function OWeeSchema() {
                         <h1 className="OWeeActiviteitNaam">Delftse Hout relax</h1>
                         <p className="OWeeActiviteitTijd">11:30-13:00</p>
                         <p className="OWeeActiviteitPlaats">Delftse Hout</p>
-                        <p className="OWeeActiviteitPlaats">Klik voor meer info</p>
+                        <span className="OWeeTooltip">Klik voor meer info</span>
                     </div>
                 </div>
             </div>
-            {/* Parade popup */}
+            {/* De popup ligt als overlay over de planning heen. Klik naast de
+                popup (op de overlay zelf) om hem te sluiten. */}
             {showPopup !== null && (
-                <div className="popup">
+                <div className="popupOverlay" onClick={() => setShowPopup(null)}>
+                <div
+                    className="popup"
+                    role="dialog"
+                    aria-modal="true"
+                    onClick={(e) => e.stopPropagation()}
+                >
 <button className="closePopup" onClick={() => setShowPopup(null)} aria-label="Sluiten">
                     ×
                 </button>
@@ -225,7 +250,7 @@ function OWeeSchema() {
                         </>
                     )}
                 </div>
-                
+                </div>
             )}
             
         </div>

--- a/src/pages/owee/components/OWeeSchema.tsx
+++ b/src/pages/owee/components/OWeeSchema.tsx
@@ -176,7 +176,12 @@ function OWeeSchema() {
                             <div className="popupText">
                                 <h2>Training</h2>
                                 <p>De maandag en woensdag kan worden afgesloten met een sportieve training bij ons op de atletiekbaan, op het adres Sportring 12. Proeftrainen kan 3 keer gratis en zelfs tijdens de OWee! </p>
-                                <p>Meld je hier aan voor een <a href="https://dsavdodeka.nl/trainingen/">proeftraining</a></p>
+                                <a className="OWeeInschrijfKnop" href="https://dsavdodeka.nl/trainingen/" target="_blank" rel="noreferrer">
+                                    Meld je aan voor een proeftraining
+                                    <svg className="OWeeInschrijfKnopPijl" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                                        <path d="M13.025 1l-2.847 2.828 6.176 6.176h-16.354v3.992h16.354l-6.176 6.176 2.847 2.828 10.975-11z" />
+                                    </svg>
+                                </a>
                             </div>
                             <img className="OWeeImagePopup" src={training_rennen} />
                         </div>
@@ -192,7 +197,13 @@ function OWeeSchema() {
                                 <br></br>
                                 <p>Onderweg zal er gestopt worden bij kaaslokaal Delft om te genieten van een gratis blokje kaas. Na deze korte pauze gaat de run verder, we eindigen bij Piada at the canal, waar deelnemers die het tot het einde hebben gehaald beloond worden met een gratis Piade. </p>
                                 <br></br>
-                                <p>Ook zonder sportkleding of de hipste hardloopschoenen ben je welkom om deel te nemen. Inschrijven kan via deze <a href = "https://docs.google.com/forms/d/1LPveictqRrqoOw4EwtREOpF4oxneMskBCbn8fzhwjEw/edit">link </a></p>                                
+                                <p>Ook zonder sportkleding of de hipste hardloopschoenen ben je welkom om deel te nemen.</p>
+                                <a className="OWeeInschrijfKnop" href="https://docs.google.com/forms/d/e/1FAIpQLScaKjcdk330TxKcTaVkdwLJXSA7JScnKfdfgMYHLzJyGQ4EKw/viewform" target="_blank" rel="noreferrer">
+                                    Schrijf je in voor de Runclub
+                                    <svg className="OWeeInschrijfKnopPijl" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                                        <path d="M13.025 1l-2.847 2.828 6.176 6.176h-16.354v3.992h16.354l-6.176 6.176 2.847 2.828 10.975-11z" />
+                                    </svg>
+                                </a>
                             </div>
                             <img className="OWeeImagePopup" src={run} />
                         </div>

--- a/src/pages/owee/components/OWeeSchema.tsx
+++ b/src/pages/owee/components/OWeeSchema.tsx
@@ -176,7 +176,7 @@ function OWeeSchema() {
                             <div className="popupText">
                                 <h2>Training</h2>
                                 <p>De maandag en woensdag kan worden afgesloten met een sportieve training bij ons op de atletiekbaan, op het adres Sportring 12. Proeftrainen kan 3 keer gratis en zelfs tijdens de OWee! </p>
-                                <a className="OWeeInschrijfKnop" href="https://dsavdodeka.nl/trainingen/" target="_blank" rel="noreferrer">
+                                <a className="OWeeInschrijfKnop" href="https://docs.google.com/forms/d/e/1FAIpQLSfNeX4zWJoujKnY_sgDss_hFAd9F_rub1zdPCu6aJ479GBq6A/viewform" target="_blank" rel="noreferrer">
                                     Meld je aan voor een proeftraining
                                     <svg className="OWeeInschrijfKnopPijl" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
                                         <path d="M13.025 1l-2.847 2.828 6.176 6.176h-16.354v3.992h16.354l-6.176 6.176 2.847 2.828 10.975-11z" />

--- a/src/pages/owee/components/OWeeSchema.tsx
+++ b/src/pages/owee/components/OWeeSchema.tsx
@@ -80,9 +80,9 @@ function OWeeSchema() {
                         <span className="OWeeTooltip">Klik voor meer info</span>
                     </div>
                     <div className="OWeeActiviteit" onClick={() => setShowPopup("Sportfeest")}>
-                        <h1 className="OWeeActiviteitNaam">Sportfeest</h1>
+                        <h1 className="OWeeActiviteitNaam">Sportfeest <span className="OWeeActiviteitNaamVenue">@ Proteus</span></h1>
                         <p className="OWeeActiviteitTijd">20:30-03:00</p>
-                        <p className="OWeeActiviteitPlaats">Proteus, Rotterdamseweg 362a</p>
+                        <p className="OWeeActiviteitPlaats">Rotterdamseweg 362a</p>
                         <span className="OWeeTooltip">Klik voor meer info</span>
                     </div>
                 </div>

--- a/src/pages/owee/components/OWeeSchema.tsx
+++ b/src/pages/owee/components/OWeeSchema.tsx
@@ -1,5 +1,6 @@
 import "./OWeeSchema.scss";
 import { useEffect, useState } from "react";
+import { Link } from "react-router";
 import parade from "$images/owee/parade.webp";
 import activiteitenmarkt from "$images/owee/activiteitenmarkt.webp";
 import borrel from "$images/owee/borrel.webp";
@@ -47,10 +48,14 @@ import run from "$images/owee/run.webp";
  * van de twee iets anders in de popup staan, geef die dan een eigen sleutel.
  *
  * Een INSCHRIJFKNOP in een popup (zoals bij Training en Runclub): kopieer het
- * <a className="OWeeInschrijfKnop"> ... </a> blok en zet de juiste link in href.
- * Gebruik bij Google Formulieren de deel-link (die eindigt op /viewform), niet
- * de link uit de adresbalk terwijl je het formulier aan het bewerken bent (die
- * eindigt op /edit) — die werkt niet voor bezoekers.
+ * blok met className="OWeeInschrijfKnop". Verwijst hij naar een pagina op onze
+ * eigen site, gebruik dan <Link to="/trainingen">; gaat hij naar buiten (een
+ * Google Formulier bijvoorbeeld), gebruik dan <a href="..." target="_blank">.
+ *
+ * Let op bij Google Formulieren: gebruik de deel-link uit de knop "Verzenden"
+ * (die ziet eruit als .../forms/d/e/LANGE-CODE/viewform). De link uit de
+ * adresbalk terwijl je het formulier zelf aan het bewerken bent eindigt op
+ * /edit en stuurt bezoekers naar een "toegang aanvragen"-scherm.
  *
  * Kleuren, afstanden en de vormgeving staan in OWeeSchema.scss.
  * De knop naar het interesseformulier onder de planning is een los bestand:
@@ -89,13 +94,13 @@ function OWeeSchema() {
                         <h1 className="OWeeActiviteitNaam">Parade</h1>
                         <p className="OWeeActiviteitTijd">16:45-19:00</p>
                         <p className="OWeeActiviteitPlaats">Langs de Schie</p>
-                        <span className="OWeeTooltip">Klik voor meer info</span>
+                        <span className="OWeeActiviteitInfo">Klik voor meer info</span>
                     </div>
                     { <div className="OWeeActiviteit" onClick={() => setShowPopup("Feest")}>
                         <h1 className="OWeeActiviteitNaam">Openingsfeest</h1>
                         <p className="OWeeActiviteitTijd">20:00-01:00</p>
                         <p className="OWeeActiviteitPlaats">Tu Delft Aula</p>
-                        <span className="OWeeTooltip">Klik voor meer info</span>
+                        <span className="OWeeActiviteitInfo">Klik voor meer info</span>
                     </div>}
                 </div>
                 <div className="OWeeDag">
@@ -105,13 +110,13 @@ function OWeeSchema() {
                         <h1 className="OWeeActiviteitNaam">Infomarkt</h1>
                         <p className="OWeeActiviteitTijd">13:00-17:45</p>
                         <p className="OWeeActiviteitPlaats">Grote Markt</p>
-                        <span className="OWeeTooltip">Klik voor meer info</span>
+                        <span className="OWeeActiviteitInfo">Klik voor meer info</span>
                     </div>
                     <div className="OWeeActiviteit" onClick={() => setShowPopup("Training")}>
                         <h1 className="OWeeActiviteitNaam">Training</h1>
                         <p className="OWeeActiviteitTijd">18:15-19:45</p>
                         <p className="OWeeActiviteitPlaats">Sportring 12</p>
-                        <span className="OWeeTooltip">Klik voor meer info</span>
+                        <span className="OWeeActiviteitInfo">Klik voor meer info</span>
                     </div>
                 </div>
                 <div className="OWeeDag">
@@ -121,13 +126,13 @@ function OWeeSchema() {
                         <h1 className="OWeeActiviteitNaam">Runclub</h1>
                         <p className="OWeeActiviteitTijd">10:30-11:30</p>
                         <p className="OWeeActiviteitPlaats">Grote Markt</p>
-                        <span className="OWeeTooltip">Klik voor meer info</span>
+                        <span className="OWeeActiviteitInfo">Klik voor meer info</span>
                     </div>
                     <div className="OWeeActiviteit" onClick={() => setShowPopup("Sportfeest")}>
                         <h1 className="OWeeActiviteitNaam">Sportfeest <span className="OWeeActiviteitNaamVenue">@ Proteus</span></h1>
                         <p className="OWeeActiviteitTijd">20:30-03:00</p>
                         <p className="OWeeActiviteitPlaats">Rotterdamseweg 362a</p>
-                        <span className="OWeeTooltip">Klik voor meer info</span>
+                        <span className="OWeeActiviteitInfo">Klik voor meer info</span>
                     </div>
                 </div>
                 <div className="OWeeDag">
@@ -137,19 +142,19 @@ function OWeeSchema() {
                         <h1 className="OWeeActiviteitNaam">Activiteitenmarkt </h1>
                         <p className="OWeeActiviteitTijd">11:00-15:00</p>
                         <p className="OWeeActiviteitPlaats">Op X</p>
-                        <span className="OWeeTooltip">Klik voor meer info</span>
+                        <span className="OWeeActiviteitInfo">Klik voor meer info</span>
                     </div>
                     <div className="OWeeActiviteit" onClick={() => setShowPopup("Training")}>
                         <h1 className="OWeeActiviteitNaam">Training</h1>
                         <p className="OWeeActiviteitTijd">18:15-19:45</p>
                         <p className="OWeeActiviteitPlaats">Sportring 12</p>
-                        <span className="OWeeTooltip">Klik voor meer info</span>
+                        <span className="OWeeActiviteitInfo">Klik voor meer info</span>
                     </div>
                     <div className="OWeeActiviteit" onClick={() => setShowPopup("Borrel")}>
                         <h1 className="OWeeActiviteitNaam">Borrel</h1>
                         <p className="OWeeActiviteitTijd">20:00-23:00</p>
                         <p className="OWeeActiviteitPlaats">Sportring 12</p>
-                        <span className="OWeeTooltip">Klik voor meer info</span>
+                        <span className="OWeeActiviteitInfo">Klik voor meer info</span>
                     </div>
                 </div>
                 <div className="OWeeDag">
@@ -159,7 +164,7 @@ function OWeeSchema() {
                         <h1 className="OWeeActiviteitNaam">Delftse Hout relax</h1>
                         <p className="OWeeActiviteitTijd">11:30-13:00</p>
                         <p className="OWeeActiviteitPlaats">Delftse Hout</p>
-                        <span className="OWeeTooltip">Klik voor meer info</span>
+                        <span className="OWeeActiviteitInfo">Klik voor meer info</span>
                     </div>
                 </div>
             </div>
@@ -226,12 +231,15 @@ function OWeeSchema() {
                             <div className="popupText">
                                 <h2>Training</h2>
                                 <p>De maandag en woensdag kan worden afgesloten met een sportieve training bij ons op de atletiekbaan, op het adres Sportring 12. Proeftrainen kan 3 keer gratis en zelfs tijdens de OWee! </p>
-                                <a className="OWeeInschrijfKnop" href="https://docs.google.com/forms/d/e/1FAIpQLSfNeX4zWJoujKnY_sgDss_hFAd9F_rub1zdPCu6aJ479GBq6A/viewform" target="_blank" rel="noreferrer">
+                                {/* Verwijst naar onze eigen trainingenpagina; daar staat alles
+                                    over de trainingen en het proeftrainen. <Link> in plaats van
+                                    <a> houdt het binnen de site (geen herlaadbeurt). */}
+                                <Link className="OWeeInschrijfKnop" to="/trainingen">
                                     Meld je aan voor een proeftraining
                                     <svg className="OWeeInschrijfKnopPijl" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
                                         <path d="M13.025 1l-2.847 2.828 6.176 6.176h-16.354v3.992h16.354l-6.176 6.176 2.847 2.828 10.975-11z" />
                                     </svg>
-                                </a>
+                                </Link>
                             </div>
                             <img className="OWeeImagePopup" src={training_rennen} />
                         </div>

--- a/src/pages/owee/components/OWeeSchema.tsx
+++ b/src/pages/owee/components/OWeeSchema.tsx
@@ -80,9 +80,9 @@ function OWeeSchema() {
                         <span className="OWeeTooltip">Klik voor meer info</span>
                     </div>
                     <div className="OWeeActiviteit" onClick={() => setShowPopup("Sportfeest")}>
-                        <h1 className="OWeeActiviteitNaam">Sportfeest bij Proteus</h1>
+                        <h1 className="OWeeActiviteitNaam">Sportfeest</h1>
                         <p className="OWeeActiviteitTijd">20:30-03:00</p>
-                        <p className="OWeeActiviteitPlaats">Rotterdamseweg 362a</p>
+                        <p className="OWeeActiviteitPlaats">Proteus, Rotterdamseweg 362a</p>
                         <span className="OWeeTooltip">Klik voor meer info</span>
                     </div>
                 </div>

--- a/src/pages/owee/components/OWeeText.tsx
+++ b/src/pages/owee/components/OWeeText.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router";
 import "./OWeeText.scss";
 
 function OWeeText() {
@@ -12,7 +13,7 @@ function OWeeText() {
                 <br/><br/>
                 Bereid je als nieuw lid voor op onder andere een super gezellig trainingsweekend, geweldige Dodeka merch, NSK’s, gala’s, friettafels, borrels, quizavonden, de jaarlijkse ski- en zomerreis, feesten in Delft en andere studentensteden en nog veel meer! Zien we jou binnenkort ook op onze atletiekbaan en bij de borrel?
                 <br/><br/>
-                Heb je interesse om proeftrainingen te volgen of lid te worden? Vul dan <a className="OWeeLink" rel="noreferrer" target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLSc4xozvdVigejC7rAnqe9x41SFxnAe6YvS4cNgLsiTQOP8bDQ/viewform">dit interesseformulier</a> in en geef je <a className="OWeeLink" rel="noreferrer" target="_blank" href="https://forms.gle/MwUuoEcFKzLT7PmU6">hier</a> op voor de trainingen! Je zult hierna een mail krijgen met meer informatie over de vereniging en hoe je lid kunt worden.
+                Heb je interesse om proeftrainingen te volgen of lid te worden? Vul dan <a className="OWeeLink" rel="noreferrer" target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLSc4xozvdVigejC7rAnqe9x41SFxnAe6YvS4cNgLsiTQOP8bDQ/viewform">dit interesseformulier</a> in en geef je <Link className="OWeeLink" to="/trainingen">hier</Link> op voor de trainingen! Je zult hierna een mail krijgen met meer informatie over de vereniging en hoe je lid kunt worden.
             </p>
             
             

--- a/src/pages/owee/components/OWeeText.tsx
+++ b/src/pages/owee/components/OWeeText.tsx
@@ -12,7 +12,7 @@ function OWeeText() {
                 <br/><br/>
                 Bereid je als nieuw lid voor op onder andere een super gezellig trainingsweekend, geweldige Dodeka merch, NSK’s, gala’s, friettafels, borrels, quizavonden, de jaarlijkse ski- en zomerreis, feesten in Delft en andere studentensteden en nog veel meer! Zien we jou binnenkort ook op onze atletiekbaan en bij de borrel?
                 <br/><br/>
-                Heb je interesse om proeftrainingen te volgen of lid te worden? Vul dan <a className="OWeeLink" rel="noreferrer" target="_blank" href="https://docs.google.com/forms/d/1oxEdLnnG-5H6Pwy_g_e-UHH5Yd7Dn5-6D4irG7nAuEY/edit">dit interesseformulier</a> in en geef je <a className="OWeeLink" rel="noreferrer" target="_blank" href="https://forms.gle/MwUuoEcFKzLT7PmU6">hier</a> op voor de trainingen! Je zult hierna een mail krijgen met meer informatie over de vereniging en hoe je lid kunt worden.
+                Heb je interesse om proeftrainingen te volgen of lid te worden? Vul dan <a className="OWeeLink" rel="noreferrer" target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLSc4xozvdVigejC7rAnqe9x41SFxnAe6YvS4cNgLsiTQOP8bDQ/viewform">dit interesseformulier</a> in en geef je <a className="OWeeLink" rel="noreferrer" target="_blank" href="https://forms.gle/MwUuoEcFKzLT7PmU6">hier</a> op voor de trainingen! Je zult hierna een mail krijgen met meer informatie over de vereniging en hoe je lid kunt worden.
             </p>
             
             

--- a/src/pages/owee/owee.tsx
+++ b/src/pages/owee/owee.tsx
@@ -1,5 +1,6 @@
 import PageTitle from "../../components/PageTitle";
 import OWeeSchema from "./components/OWeeSchema";
+import OWeeInteresse from "./components/OWeeInteresse";
 import OWeeText from "./components/OWeeText";
 import OWeeImageBar from "./components/OWeeImageBar";
 import "./owee.scss";
@@ -8,7 +9,8 @@ function OWee() {
     return(
         <div>
             <PageTitle title="OWee"/>
-            <OWeeSchema />  
+            <OWeeSchema />
+            <OWeeInteresse />
             <OWeeText />
             <OWeeImageBar />
         </div>


### PR DESCRIPTION
## TL;DR

De OWee-planning kreeg feedback op promotie en gebruiksgemak. De info van een activiteit opent nu als popup **over** de planning heen (in plaats van de planning te vervangen) en sluit met een klik ernaast of Escape, elke activiteit draagt zichtbaar een "Klik voor meer info"-labeltje, en er staat een duidelijke knop naar het interesseformulier onder de planning. Daarnaast heeft de planning meer lucht gekregen en zijn een paar links gerepareerd die bezoekers naar een "toegang aanvragen"-scherm van Google stuurden.

Belangrijk voor de reviewer: de opzet van de OWee-code is bewust **niet** herschreven. De activiteiten staan nog steeds als losse, leesbare blokken in `OWeeSchema.tsx` (geen array + `.map()`), zodat de commissie ze volgend jaar gewoon kan kopiëren en aanpassen. Bovenaan dat bestand staat nu uitleg in gewone taal hoe dat moet.

## Context

De planning was al gebouwd door de OWee-commissie (#204, #208). De feedback ging over drie dingen:

1. **Klik je een activiteit aan, dan verdween de hele planning** en kwam er een los blok voor in de plaats (`className={showPopup ? "planning hidden" : "planning"}`). Je verloor je overzicht en kon alleen terug via het kruisje.
2. **"Klik voor meer info" viel niet op**: het stond als vierde `<p className="OWeeActiviteitPlaats">` onder de locatie, dus in dezelfde stijl als "Grote Markt" — het las als een derde adresregel, niet als een uitnodiging om te klikken.
3. **Promotie**: er was geen zichtbare route van de planning naar het interesseformulier, en bij Training en Runclub (de enige twee activiteiten waarvoor je je moet inschrijven) zat die actie verstopt als tekstlink midden in een alinea.

## How it works

### De popup ligt nu over de planning

De planning blijft altijd staan. De popup zit in een extra laag (`.popupOverlay`) die over de hele pagina ligt; een klik daarop sluit, een klik op het witte kaartje zelf niet (`stopPropagation`). Een `useEffect` luistert zolang de popup open staat naar Escape en zet `document.body.style.overflow` op `hidden`, zodat de pagina eronder niet meescrolt. De opruimfunctie zet de oude waarde terug, ook als je via een link de pagina verlaat.

```mermaid
stateDiagram-v2
    [*] --> Planning
    Planning --> Popup: klik op een activiteit
    Popup --> Planning: klik naast de popup
    Popup --> Planning: Escape
    Popup --> Planning: kruisje
    Popup --> Popup: klik in de popup zelf
```

### Kaartje en popup horen bij elkaar via een sleutelwoord

Dat was al zo (`setShowPopup("Borrel")` ↔ `showPopup === "Borrel"`), maar het stond nergens. Typ je die twee verschillend, dan gebeurt er bij het klikken niets — geen foutmelding, geen spoor. Dat is nu het eerste wat het bestand uitlegt, samen met stap-voor-stap instructies voor het toevoegen/weghalen van een activiteit of een dag, waar de foto's vandaan komen, en de valkuil dat "Training" twee keer in de planning staat en dus één gedeelde popup heeft.

### Waar de knoppen naartoe gaan

```mermaid
flowchart TD
    Page["owee.tsx"] --> Schema["OWeeSchema<br/>planning + popups"]
    Page --> Interesse["OWeeInteresse (nieuw)"]
    Page --> Text["OWeeText"]
    Schema -->|"Training-popup"| Trainingen["/trainingen"]
    Schema -->|"Runclub-popup"| RunForm["Google Formulier: Runclub"]
    Interesse --> InteresseForm["Google Formulier: interesse"]
    Text --> InteresseForm
    Text --> Trainingen
```

De interesseknop staat **onder** de planning, niet erboven: daar is iemand net door alle activiteiten gescrold en is de vraag "en hoe doe ik mee?" op zijn sterkst. Erboven zou hij om een inschrijving vragen voordat het programma zijn werk heeft gedaan, en de planning omlaag duwen.

### Twee kapotte links

De Runclub-inschrijving en het interesseformulier wezen naar de `/edit`-URL van het Google Formulier — de link uit de adresbalk terwijl je het formulier zelf aan het bewerken bent. Bezoekers komen daarmee op een "toegang aanvragen"-scherm in plaats van op het formulier. Beide gebruiken nu de publieke deel-link (`/forms/d/e/…/viewform`). Die valkuil staat ook in de uitleg bovenaan `OWeeSchema.tsx`, want hij is hier nu twee keer gemaakt.

### Een hover-bug die tijdens dit werk ontstond

Er stonden twee oude regels in de SCSS:

```scss
.OWeeActiviteit:hover  { margin: 1rem; }
.OWeeActiviteit:active { margin: 1rem; }
```

Die deden niets zolang de kaartjes zelf ook `margin: 1rem` hadden. Toen de marges veranderden voor de nieuwe indeling, zette hover ineens wél een andere marge — het kaartje verschoot van vorm en het labeltje brak over twee regels. Beide regels zijn weg; hover is nu een zetje omhoog met schaduw (`translateY(-3px)`), wat niets aan de indeling verandert.

## What changed

<details>
<summary><code>src/pages/owee/components/OWeeSchema.tsx</code> — planning en popups</summary>

- `.popupOverlay` om de popup heen, met `stopPropagation` op het witte kaartje; `role="dialog"` en `aria-modal="true"`.
- `useEffect` voor Escape + het vastzetten van de pagina eronder.
- De planning wordt niet langer verborgen als er een popup open staat.
- "Klik voor meer info" is van een `<p className="OWeeActiviteitPlaats">` een `<span className="OWeeActiviteitInfo">` geworden.
- Titel van het sportfeest: "Sportfeest bij Proteus" liep als enige over twee regels. Nu "Sportfeest @ Proteus", waarbij `@ Proteus` in een kleinere span staat.
- Inschrijfknoppen (`.OWeeInschrijfKnop`) in de Training- en Runclub-popup, in plaats van tekstlinks in een alinea. Training gaat via `<Link>` naar `/trainingen`, Runclub naar het formulier.
- Uitlegblok bovenaan + een kopje boven de popups.

</details>

<details>
<summary><code>src/pages/owee/components/OWeeSchema.scss</code> — indeling en vormgeving</summary>

- De dagkolommen stonden op `inline-block` met `width: calc(20% - 1rem)` plus zowel een `margin-right` als een `padding-right`; dat is nu een grid met één `gap: 2.5rem`.
- `grid-auto-flow: column` met `grid-auto-columns: minmax(0, 1fr)`: het aantal dagen staat nergens meer vast (eerst `repeat(5, 1fr)`, waarbij een zesde dag stil buiten beeld zou vallen) en één lang adres kan een kolom niet meer breder trekken.
- Afstanden volgen nu de groepering: dag → datum 0.125rem, kop → eerste kaartje 1.25rem, kaartje → kaartje 0.75rem, dag → dag 2.5rem. Op mobiel vervangt `.OWeeDag + .OWeeDag { margin-top: 2rem }` de grid-gap.
- De planning is licht doorschijnend (`rgba(255, 255, 255, 0.9)` + `backdrop-filter: blur(3px)`), zodat de achtergrondfoto er nog doorheen komt; op mobiel blijft hij dekkend.
- De blauwe balken boven en onder de foto (`border-top`/`border-bottom: 4rem`) zijn weg, en het kader eromheen is ruimer.
- Nieuw: `.OWeeActiviteitInfo` (het rode labeltje), `.OWeeActiviteitNaamVenue`, `.OWeeInschrijfKnop`, `.popupOverlay`.
- Alle animaties respecteren `prefers-reduced-motion`.

</details>

<details>
<summary><code>OWeeInteresse.tsx</code> / <code>.scss</code> (nieuw) en <code>owee.tsx</code></summary>

Losse component met kop "Interesse gekregen?", één regel uitleg en de knop naar het interesseformulier. Wordt in `owee.tsx` tussen `<OWeeSchema />` en `<OWeeText />` gezet. De knop is 52px hoog (ruim boven de 44px die een vinger nodig heeft), heeft hover-, actief- en focusstijlen, en opent het formulier in een nieuw tabblad.

</details>

<details>
<summary><code>src/pages/owee/components/OWeeText.tsx</code></summary>

Twee links in dezelfde zin: "dit interesseformulier" wees naar de `/edit`-URL (nu de publieke deel-link), en "geef je hier op voor de trainingen" wees naar een los Google Formulier (nu `<Link to="/trainingen">`, net als de knop in de Training-popup).

</details>

## Before / after

| | Voor | Na |
|---|---|---|
| Activiteit aanklikken | planning verdwijnt, los infoblok verschijnt | popup over de planning, planning blijft zichtbaar |
| Popup sluiten | alleen het kruisje | kruisje, klik ernaast of Escape |
| "Klik voor meer info" | vierde adresregel in dezelfde stijl | rood labeltje, altijd zichtbaar |
| Inschrijven Training/Runclub | tekstlink midden in een alinea | eigen knop onder de tekst |
| Naar het interesseformulier | alleen een link in de lopende tekst | knop direct onder de planning |

Screenshots van de planning, de popup en beide inschrijfknoppen voeg ik in een reactie toe.

## Verification

Handmatig nagelopen in de browser op 1440px, 1280px en 375px (mobiel), met een echte klik (niet alleen code lezen):

- Popup openen; sluiten via kruisje, klik op de overlay en Escape. Na sluiten staat `document.body.style.overflow` weer leeg, ook als je via de Training-knop de pagina verlaat.
- Klik binnen de popup sluit hem niet.
- Training-knop navigeert naar `/trainingen` zonder herlaadbeurt; "hier"-link in de tekst idem.
- Alle tien de labeltjes pakken de nieuwe klassenaam op.
- Dat de planning zichzelf indeelt is getest door er tijdelijk een zesde dag in te injecteren: zes even brede kolommen.
- De formulier-URL's zijn met `curl` gecontroleerd: de publieke links geven 200 op het formulier zelf, de oude `/edit`-varianten komen uit op `viewform?edit_requested=true`.

`npm run check` geeft geen nieuwe fouten (de bestaande meldingen in `AdminOld`/`LedenOld`, `sprint-tijden` en `OWeeImageBar` stonden er al).

Nog open, bewust niet in deze PR:

- **Geen `Changelog.json`-entry**: dit bouwt voort op het werk van de OWee-commissie.
- "Delftse Hout relax" past op 1440px op één regel, maar loopt onder ~1280px over twee regels. Een kortere naam zou dat oplossen.
- De Runclub-inschrijving blijft een extern Google Formulier; daar is geen pagina op de site voor.
