### PR TITLE
Preload OWee popup photos and log the beunsessie in the changelog

### DIFF
--- a/src/content/Changelog.json
+++ b/src/content/Changelog.json
@@ -1,6 +1,17 @@
 {
   "updates": [
     {
+      "id": "feature-owee-pagina-beunsessie",
+      "datum": "15-08-2026",
+      "titel": "OWee-pagina geüpdatet en geüpgraded",
+      "beschrijving": "Tijdens onze beunsessie hebben we de OWee-pagina geüpdatet en geüpgraded: een nieuw programmaschema waarin je op elke activiteit kunt klikken voor een pop-up met uitleg, verse foto's van de trainingen, de parade en de borrel, en een nieuwe achtergrond. De foto's worden nu vooraf geladen, dus een pop-up staat er meteen.",
+      "categorie": "feature",
+      "grootte": "groot",
+      "auteur": "Ymme, Mei Chang, Anne-Wil, Xylander, Tijmen en Jefry",
+      "link": "/owee",
+      "momentId": "beunsessie-2026"
+    },
+    {
       "id": "bugfix-owee-video-sneller",
       "datum": "15-08-2026",
       "titel": "OWee-video op de voorpagina laadt nu direct",
@@ -24,7 +35,7 @@
       "titel": "OWee-video en banner op de voorpagina",
       "beschrijving": "De voorpagina opent nu met een schermvullende OWee-video, en een opvallende banner brengt je in één klik naar al onze OWee-activiteiten. Zo vinden nieuwe studenten ons meteen.",
       "categorie": "feature",
-      "grootte": "groot",
+      "grootte": "klein",
       "auteur": "Jefry",
       "link": "/owee"
     },
@@ -432,6 +443,12 @@
     }
   ],
   "momenten": [
+    {
+      "id": "beunsessie-2026",
+      "naam": "Beunsessie 2026",
+      "datum": "15-08-2026",
+      "beschrijving": "Updates die tijdens onze beunsessie zijn gebouwd en uitgerold."
+    },
     {
       "id": "24uursvergadering-2026",
       "naam": "24-uursvergadering 2026",

--- a/src/pages/owee/components/OWeeSchema.tsx
+++ b/src/pages/owee/components/OWeeSchema.tsx
@@ -62,8 +62,31 @@ import run from "$images/owee/run.webp";
  * OWeeInteresse.tsx.
  */
 
+// Alle foto's die alleen in een popup staan. Ze worden meteen bij het openen van
+// de pagina opgehaald, zodat de foto er al staat als je op een activiteit klikt.
+// Voeg een nieuwe popup-foto hier ook toe.
+const popupImages = [
+    parade,
+    activiteitenmarkt,
+    borrel,
+    Chillen_op_gras,
+    infomarkt,
+    sportfeest,
+    trackFestival,
+    training_rennen,
+    run,
+];
+
 function OWeeSchema() {
     const [showPopup, setShowPopup] = useState<string | null>(null);
+
+    // Haal de popup-foto's alvast op, zodat een popup meteen compleet is.
+    useEffect(() => {
+        for (const src of popupImages) {
+            const img = new Image();
+            img.src = src;
+        }
+    }, []);
 
     // Sluit de popup met Escape, en bevries de pagina eronder zolang hij open staat.
     useEffect(() => {


### PR DESCRIPTION
Two small changes from the beunsessie work on the OWee page.

## Preload the popup photos

`OWeeSchema` renders each activity popup only once it is opened, so the `<img>` inside it — and therefore the download of a 0.5–1 MB photo — did not start until you clicked. The first click on every activity showed an empty frame while the image loaded.

The nine popup-only photos are now collected in a `popupImages` array and fetched with `new Image()` from a `useEffect` on mount, so they arrive alongside the rest of the page and the popup is complete the moment it opens. Nothing about the render path changed.

## Changelog

- New entry `feature-owee-pagina-beunsessie`, grouped under a new `beunsessie-2026` moment, crediting Ymme, Mei Chang, Anne-Wil, Xylander, Tijmen and Jefry for the new clickable programme schedule, the photos and the new background.
- `feature-owee-voorpagina` (the hero video + banner) drops from `grootte: "groot"` to `"klein"`, so it renders as a compact card instead of a big featured one.

## Verification

Checked against the dev server on `/owee`:

- All nine photos are requested on page load, before any interaction.
- Opening the Parade popup yields an `<img>` that is already `complete: true` with `naturalWidth: 1250` — no loading gap.
- `Changelog.json` parses and the new moment id resolves.
- `npm run check` reports no new errors (the remaining ones are pre-existing, in test files and `OWeeImageBar.tsx`).

The only console errors on the page are the local backend on `:12780` not running, which is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)